### PR TITLE
feat(core): add LMap component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      leaflet:
+        specifier: ^2.0.0-alpha
+        version: 2.0.0-alpha
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -1533,6 +1536,9 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  leaflet@2.0.0-alpha:
+    resolution: {integrity: sha512-RnEJ3UYcuHPFFsDq0e2/QovyIaR3hhwiQpq3wrKnvprA/lsiAJpcxvkRZL3UwQ2xnKm1r2pYcMa+rcSKVwEQag==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3607,6 +3613,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  leaflet@2.0.0-alpha: {}
 
   levn@0.4.1:
     dependencies:

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import type { PropType } from 'vue'
+import type { PointExpression } from 'leaflet'
+
+const props = defineProps({
+    /**
+     * The center of the map, supports .sync modifier
+     */
+    center: {
+        type: [Object, Array] as PropType<PointExpression>,
+    },
+    /**
+     * The bounds of the map, supports .sync modifier
+     */
+    bounds: {
+        type: [Array, Object],
+    },
+    /**
+     * The max bounds of the map
+     */
+    maxBounds: {
+        type: [Array, Object],
+    },
+    /**
+     * The zoom of the map, supports .sync modifier
+     */
+    zoom: {
+        type: Number,
+    },
+    /**
+     * The minZoom of the map
+     */
+    minZoom: {
+        type: Number,
+    },
+    /**
+     * The maxZoom of the map
+     */
+    maxZoom: {
+        type: Number,
+    },
+    /**
+     * The paddingBottomRight of the map
+     */
+    paddingBottomRight: {
+        type: [Object, Array] as PropType<PointExpression>,
+    },
+    /**
+     * The paddingTopLeft of the map
+     */
+    paddingTopLeft: {
+        type: Object as PropType<PointExpression>,
+    },
+    /**
+     * The padding of the map
+     */
+    padding: {
+        type: PointExpression
+    },
+    /**
+     * The worldCopyJump option for the map
+     */
+    worldCopyJump: {
+        type: Boolean,
+        default: undefined,
+    },
+    /**
+     * The CRS to use for the map. Can be an object that defines a coordinate reference
+     * system for projecting geographical points into screen coordinates and back
+     * (see https://leafletjs.com/reference-1.7.1.html#crs-l-crs-base), or a string
+     * name identifying one of Leaflet's defined CRSs, such as "EPSG4326".
+     */
+    crs: {
+        type: [String, Object],
+    },
+    maxBoundsViscosity: {
+        type: Number,
+    },
+    inertia: {
+        type: Boolean,
+        default: undefined,
+    },
+    inertiaDeceleration: {
+        type: Number,
+    },
+    inertiaMaxSpeed: {
+        type: Number,
+    },
+    easeLinearity: {
+        type: Number,
+    },
+    zoomAnimation: {
+        type: Boolean,
+        default: undefined,
+    },
+    zoomAnimationThreshold: {
+        type: Number,
+    },
+    fadeAnimation: {
+        type: Boolean,
+        default: undefined,
+    },
+    markerZoomAnimation: {
+        type: Boolean,
+        default: undefined,
+    },
+    noBlockingAnimations: {
+        type: Boolean,
+        default: undefined,
+    }
+})
+</script>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,1 @@
+export { default as LMap } from "./LMap.vue";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,1 @@
+export * from './components';

--- a/src/types/enums/LayerType.ts
+++ b/src/types/enums/LayerType.ts
@@ -1,0 +1,8 @@
+import type { ObjectValues } from "../utilityTypes";
+
+const LAYER_TYPE = {
+    BASE: "base",
+    OVERLAY: "overlay",
+} as const;
+
+export type LayerType = ObjectValues<typeof LAYER_TYPE>;

--- a/src/types/injectionKeys.ts
+++ b/src/types/injectionKeys.ts
@@ -1,7 +1,7 @@
-import type L from "leaflet";
 import type { InjectionKey } from "vue";
 
 import type { IControlDefinition, ILayerDefinition } from "./interfaces";
+import { Control } from 'leaflet'
 
 export const AddLayerInjection = Symbol("addLayer") as InjectionKey<
     (layer: ILayerDefinition) => void
@@ -17,4 +17,4 @@ export const RegisterControlInjection = Symbol(
 
 export const RegisterLayerControlInjection = Symbol(
     "registerLayerControl"
-) as InjectionKey<(control: IControlDefinition<L.Control.Layers>) => void>;
+) as InjectionKey<(control: IControlDefinition<Control.Layers>) => void>;

--- a/src/types/injectionKeys.ts
+++ b/src/types/injectionKeys.ts
@@ -1,0 +1,20 @@
+import type L from "leaflet";
+import type { InjectionKey } from "vue";
+
+import type { IControlDefinition, ILayerDefinition } from "./interfaces";
+
+export const AddLayerInjection = Symbol("addLayer") as InjectionKey<
+    (layer: ILayerDefinition) => void
+>;
+
+export const RemoveLayerInjection = Symbol("removeLayer") as InjectionKey<
+    (layer: ILayerDefinition) => void
+>;
+
+export const RegisterControlInjection = Symbol(
+    "registerControl"
+) as InjectionKey<(control: IControlDefinition) => void>;
+
+export const RegisterLayerControlInjection = Symbol(
+    "registerLayerControl"
+) as InjectionKey<(control: IControlDefinition<L.Control.Layers>) => void>;

--- a/src/types/interfaces/IControlDefinition.ts
+++ b/src/types/interfaces/IControlDefinition.ts
@@ -1,0 +1,5 @@
+import { Control } from 'leaflet'
+
+export interface IControlDefinition<T extends Control = Control> {
+    leafletObject: T;
+}

--- a/src/types/interfaces/ILayerDefinition.ts
+++ b/src/types/interfaces/ILayerDefinition.ts
@@ -1,0 +1,9 @@
+import type { LayerType } from '../enums/LayerType.ts'
+import { Layer } from 'leaflet'
+
+export interface ILayerDefinition<T extends Layer = Layer> {
+    name?: string;
+    layerType?: LayerType;
+    visible?: boolean;
+    leafletObject: T;
+}

--- a/src/types/interfaces/IMapBlueprint.ts
+++ b/src/types/interfaces/IMapBlueprint.ts
@@ -1,0 +1,11 @@
+import { LatLng, LatLngBounds, Map } from 'leaflet'
+
+export interface IMapBlueprint {
+    ready: boolean;
+    leafletRef?: Map;
+    layerControl?: any; // TODO: Proper typing, based on argument to registerLayerControl called in LControlLayers.vue
+    layersToAdd: any[]; // TODO: Proper typing
+    layersInControl: any[]; // TODO: Proper typing
+    lastSetBounds?: LatLngBounds;
+    lastSetCenter?: LatLng;
+}

--- a/src/types/interfaces/index.ts
+++ b/src/types/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from "./IControlDefinition";
+export * from "./ILayerDefinition";

--- a/src/types/utilityTypes.ts
+++ b/src/types/utilityTypes.ts
@@ -1,0 +1,1 @@
+export type ObjectValues<T> = T[keyof T];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,112 @@
-import type { LeafletEventHandlerFnMap } from 'leaflet'
+import { Evented, type LeafletEventHandlerFnMap } from 'leaflet'
+import { type DefineProps, watch } from 'vue'
 
 export const cancelDebounces = (handlerMethods: LeafletEventHandlerFnMap) => {
     for (const name of Object.keys(handlerMethods)) {
-        const handler = handlerMethods[name];
-        if(handler && isFunction(handler.cancel)) {
-            handler.cancel();
+        const handler = handlerMethods[name]
+        if (handler && isFunction(handler.cancel)) {
+            handler.cancel()
+        }
+    }
+}
+
+
+export const isFunction = (x: unknown) => typeof x === 'function'
+
+export const propsBinder = (methods, leafletElement: Evented, props) => {
+    for (const key in props) {
+        const setMethodName = "set" + capitalizeFirstLetter(key);
+        if (methods[setMethodName]) {
+            watch(
+                () => props[key],
+                (newVal, oldVal) => {
+                    methods[setMethodName](newVal, oldVal);
+                }
+            );
+        } else if (leafletElement[setMethodName]) {
+            watch(
+                () => props[key],
+                (newVal) => {
+                    leafletElement[setMethodName](newVal);
+                }
+            );
         }
     }
 };
 
+export declare type ListenersAndAttrs = {
+    listeners: LeafletEventHandlerFnMap;
+    attrs: Record<string, unknown>;
+};
 
-export const isFunction = (x: unknown) => typeof x === "function";
+export const bindEventHandlers = (
+    leafletObject: Evented,
+    eventHandlers: LeafletEventHandlerFnMap
+) => {
+    for (const eventName of Object.keys(eventHandlers)) {
+        leafletObject.on(eventName, eventHandlers[eventName])
+    }
+}
+
+export const resetWebpackIcon = async (Icon) => {
+    const modules = await Promise.all([
+        import('leaflet/dist/images/marker-icon-2x.png'),
+        import('leaflet/dist/images/marker-icon.png'),
+        import('leaflet/dist/images/marker-shadow.png')
+    ])
+
+    delete Icon.Default.prototype._getIconUrl
+
+    Icon.Default.mergeOptions({
+        iconRetinaUrl: modules[0].default,
+        iconUrl: modules[1].default,
+        shadowUrl: modules[2].default
+    })
+}
+
+export const remapEvents = (contextAttrs: Record<string, unknown>): ListenersAndAttrs => {
+    const listeners: LeafletEventHandlerFnMap = {}
+    const attrs: Record<string, unknown> = {}
+    for (const attrName in contextAttrs) {
+        if (
+            attrName.startsWith('on') &&
+            !attrName.startsWith('onUpdate') &&
+            attrName !== 'onReady'
+        ) {
+            const eventName = attrName.slice(2).toLocaleLowerCase()
+            listeners[eventName] = contextAttrs[attrName]
+        } else {
+            attrs[attrName] = contextAttrs[attrName]
+        }
+    }
+
+    return { listeners, attrs }
+}
+
+/**
+ * Wrap a placeholder function and provide it with the given name.
+ * The wrapper can later be updated with {@link updateLeafletWrapper}
+ * to provide a different function.
+ *
+ * @param {String} methodName Key used to provide the wrapper function
+ */
+export const provideLeafletWrapper = (methodName: string) => {
+    const wrapped = ref((..._args: any[]) =>
+        console.warn(`Method ${methodName} has been invoked without being replaced`)
+    );
+    const wrapper = (...args: any[]) => wrapped.value(...args);
+    wrapper.wrapped = wrapped;
+    provide(methodName, wrapper);
+
+    return wrapper;
+};
+
+/**
+ * Change the function that will be executed when an injected Leaflet wrapper
+ * is invoked.
+ *
+ * @param {*} wrapper Provided wrapper whose wrapped function is to be updated
+ * @param {function} leafletMethod New method to be wrapped by the wrapper
+ */
+export const updateLeafletWrapper = (wrapper, leafletMethod) =>
+    (wrapper.wrapped.value = leafletMethod);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,21 @@
+// REWRITE DONE
 import { Evented, type LeafletEventHandlerFnMap } from 'leaflet'
-import { type DefineProps, watch } from 'vue'
+import { type InjectionKey, provide, ref, watch } from 'vue'
+
+// BREAKING CHANGES: remove type Data
+export declare type ListenersAndAttrs = {
+    listeners: LeafletEventHandlerFnMap;
+    attrs: Record<string, unknown>;
+};
+
+export const bindEventHandlers = (
+    leafletObject: Evented,
+    eventHandlers: LeafletEventHandlerFnMap
+): void => {
+    for (const eventName of Object.keys(eventHandlers)) {
+        leafletObject.on(eventName, eventHandlers[eventName])
+    }
+}
 
 export const cancelDebounces = (handlerMethods: LeafletEventHandlerFnMap) => {
     for (const name of Object.keys(handlerMethods)) {
@@ -10,59 +26,37 @@ export const cancelDebounces = (handlerMethods: LeafletEventHandlerFnMap) => {
     }
 }
 
+export const capitalizeFirstLetter = (s: string) => {
+    if (!s || typeof s.charAt !== 'function') {
+        return s
+    }
+    return s.charAt(0).toUpperCase() + s.slice(1)
+}
 
 export const isFunction = (x: unknown) => typeof x === 'function'
 
 export const propsBinder = (methods, leafletElement: Evented, props) => {
     for (const key in props) {
-        const setMethodName = "set" + capitalizeFirstLetter(key);
+        const setMethodName = 'set' + capitalizeFirstLetter(key)
         if (methods[setMethodName]) {
             watch(
                 () => props[key],
                 (newVal, oldVal) => {
-                    methods[setMethodName](newVal, oldVal);
+                    methods[setMethodName](newVal, oldVal)
                 }
-            );
+            )
         } else if (leafletElement[setMethodName]) {
             watch(
                 () => props[key],
                 (newVal) => {
-                    leafletElement[setMethodName](newVal);
+                    leafletElement[setMethodName](newVal)
                 }
-            );
+            )
         }
     }
-};
-
-export declare type ListenersAndAttrs = {
-    listeners: LeafletEventHandlerFnMap;
-    attrs: Record<string, unknown>;
-};
-
-export const bindEventHandlers = (
-    leafletObject: Evented,
-    eventHandlers: LeafletEventHandlerFnMap
-) => {
-    for (const eventName of Object.keys(eventHandlers)) {
-        leafletObject.on(eventName, eventHandlers[eventName])
-    }
 }
 
-export const resetWebpackIcon = async (Icon) => {
-    const modules = await Promise.all([
-        import('leaflet/dist/images/marker-icon-2x.png'),
-        import('leaflet/dist/images/marker-icon.png'),
-        import('leaflet/dist/images/marker-shadow.png')
-    ])
-
-    delete Icon.Default.prototype._getIconUrl
-
-    Icon.Default.mergeOptions({
-        iconRetinaUrl: modules[0].default,
-        iconUrl: modules[1].default,
-        shadowUrl: modules[2].default
-    })
-}
+// BREAKING CHANGES: remove propsToLeafletOptions
 
 export const remapEvents = (contextAttrs: Record<string, unknown>): ListenersAndAttrs => {
     const listeners: LeafletEventHandlerFnMap = {}
@@ -83,6 +77,23 @@ export const remapEvents = (contextAttrs: Record<string, unknown>): ListenersAnd
     return { listeners, attrs }
 }
 
+
+export const resetWebpackIcon = async (Icon) => {
+    const modules = await Promise.all([
+        import('leaflet/dist/images/marker-icon-2x.png'),
+        import('leaflet/dist/images/marker-icon.png'),
+        import('leaflet/dist/images/marker-shadow.png')
+    ])
+
+    delete Icon.Default.prototype._getIconUrl
+
+    Icon.Default.mergeOptions({
+        iconRetinaUrl: modules[0].default,
+        iconUrl: modules[1].default,
+        shadowUrl: modules[2].default
+    })
+}
+
 /**
  * Wrap a placeholder function and provide it with the given name.
  * The wrapper can later be updated with {@link updateLeafletWrapper}
@@ -90,16 +101,16 @@ export const remapEvents = (contextAttrs: Record<string, unknown>): ListenersAnd
  *
  * @param {String} methodName Key used to provide the wrapper function
  */
-export const provideLeafletWrapper = (methodName: string) => {
+export const provideLeafletWrapper = (methodName: InjectionKey<unknown>) => {
     const wrapped = ref((..._args: any[]) =>
-        console.warn(`Method ${methodName} has been invoked without being replaced`)
-    );
-    const wrapper = (...args: any[]) => wrapped.value(...args);
-    wrapper.wrapped = wrapped;
-    provide(methodName, wrapper);
+        console.warn(`Method ${String(methodName)} has been invoked without being replaced`)
+    )
+    const wrapper = (...args: any[]) => wrapped.value(...args)
+    wrapper.wrapped = wrapped
+    provide(methodName, wrapper)
 
-    return wrapper;
-};
+    return wrapper
+}
 
 /**
  * Change the function that will be executed when an injected Leaflet wrapper
@@ -108,5 +119,7 @@ export const provideLeafletWrapper = (methodName: string) => {
  * @param {*} wrapper Provided wrapper whose wrapped function is to be updated
  * @param {function} leafletMethod New method to be wrapped by the wrapper
  */
-export const updateLeafletWrapper = (wrapper, leafletMethod) =>
-    (wrapper.wrapped.value = leafletMethod);
+export const updateLeafletWrapper = (wrapper, leafletMethod: Function) =>
+    (wrapper.wrapped.value = leafletMethod)
+
+// BREAKING CHANGES: remove WINDOW_OR_GLOBAL

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,13 @@
+import type { LeafletEventHandlerFnMap } from 'leaflet'
+
+export const cancelDebounces = (handlerMethods: LeafletEventHandlerFnMap) => {
+    for (const name of Object.keys(handlerMethods)) {
+        const handler = handlerMethods[name];
+        if(handler && isFunction(handler.cancel)) {
+            handler.cancel();
+        }
+    }
+};
+
+
+export const isFunction = (x: unknown) => typeof x === "function";


### PR DESCRIPTION
LMap component has been added. It comes with a few breaking changes.
It is no longer needed to useGlobalLeaflet to make the component ssr compatible.
The leaflet options have been ported to the declared class in leaflet. Therefore LMap accepts the mapOptions as a prop instead of all options to clarify what is connected to leaflet and the component itself.