### PR TITLE
fix(core): emit is now available on setup in LGridLayer and LTileLayer

### DIFF
--- a/src/components/LGridLayer.vue
+++ b/src/components/LGridLayer.vue
@@ -20,11 +20,10 @@ const props = withDefaults(
     gridLayerPropsDefaults,
 )
 
+const emit = defineEmits<GridLayerEmits>()
 const {leafletObject, root, ready} = useGridLayer()
 
 defineExpose({ root, ready, leafletObject })
-
-const emit = defineEmits<GridLayerEmits>()
 
 function useGridLayer() {
     const leafletObject = ref<GridLayer>()

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { markRaw, nextTick, onMounted, type Ref, ref, useAttrs } from 'vue'
+import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 import { TileLayer } from 'leaflet'
 import { assertInject, propsBinder, remapEvents } from '../utils.ts'
 import { AddLayerInjection } from '../types/injectionKeys.ts'
@@ -11,10 +11,9 @@ import {
 } from '../functions/tileLayer.ts'
 
 const props = withDefaults(defineProps<TileLayerProps>(), tileLayerPropsDefaults)
+const emit = defineEmits<TileLayerEmits>()
 
 const { leafletObject } = useTileLayer()
-
-const emit = defineEmits<TileLayerEmits>()
 
 defineExpose({ leafletObject })
 
@@ -22,7 +21,7 @@ function useTileLayer() {
     const leafletObject = ref<TileLayer>()
 
     const addLayer = assertInject(AddLayerInjection)
-    const { methods } = setupTileLayer(props, leafletObject as Ref<TileLayer>, emit)
+    const { methods } = setupTileLayer(props, leafletObject, emit)
 
     onMounted(async () => {
         leafletObject.value = markRaw<TileLayer>(new TileLayer(props.url, props.layerOptions))
@@ -42,4 +41,6 @@ function useTileLayer() {
 }
 </script>
 
-<template><div></div></template>
+<template>
+    <div style="display: none"></div>
+</template>

--- a/src/functions/component.ts
+++ b/src/functions/component.ts
@@ -3,7 +3,7 @@ export interface ComponentProps {
 }
 
 export const componentPropsDefaults = {
-    options: {}
+    options: () => ({})
 }
 
 export const setupComponent = () => {

--- a/src/functions/tileLayer.ts
+++ b/src/functions/tileLayer.ts
@@ -21,7 +21,7 @@ export type TileLayerEmits = GridLayerEmits<TileLayer>
 // BREAKING CHANGES: setupTileLayer does not return options anymore
 export const setupTileLayer = <T extends TileLayer>(
     props: TileLayerProps,
-    leafletRef: Ref<T>,
+    leafletRef: Ref<T | undefined>,
     emit: TileLayerEmits,
 ) => {
     const { methods: gridLayerMethods } = setupGridLayer(props, leafletRef, emit)

--- a/src/playground/views/DemoHome.vue
+++ b/src/playground/views/DemoHome.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { LMap } from '../../components'
+import { LMap, LTileLayer } from '../../components'
 import type { MapOptions } from 'leaflet'
-import { LTileLayer } from '@/components'
 
 const mapOptions: MapOptions = {
     center: [51.505, -0.09],


### PR DESCRIPTION
emit is now available on setup in LGridLayer and LTileLayer
Removed as cast in LTileLayer
Changed default value of componentPropsDefault
Changed imports in DemoHome
