### PR TITLE
feat(core): add LMarker component

### DIFF
--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import {
+    markRaw,
+    nextTick,
+    onBeforeUnmount,
+    onMounted,
+    provide,
+    ref,
+    useAttrs,
+    useSlots,
+} from 'vue'
+import {
+    assertInject,
+    bindEventHandlers,
+    cancelDebounces,
+    isFunction,
+    propsBinder,
+    remapEvents,
+} from '../utils.ts'
+import {
+    AddLayerInjection,
+    CanSetParentHtmlInjection,
+    SetIconInjection,
+    SetParentHtmlInjection,
+} from '../types/injectionKeys.ts'
+import { DivIcon, Icon, type LeafletEventHandlerFnMap, Marker } from 'leaflet'
+import { debounce } from 'ts-debounce'
+import {
+    type MarkerEmits,
+    type MarkerProps,
+    markerPropsDefaults,
+    setupMarker,
+    shouldBlankIcon,
+} from '../functions/marker.ts'
+
+const props = withDefaults(defineProps<MarkerProps>(), markerPropsDefaults)
+
+const leafletObject = ref<Marker>()
+const ready = ref<boolean>(false)
+
+defineExpose({ ready, leafletObject })
+const emit = defineEmits<MarkerEmits>()
+
+const addLayer = assertInject(AddLayerInjection)
+
+provide(CanSetParentHtmlInjection, () => !!leafletObject.value?.getElement())
+provide(SetParentHtmlInjection, (html: string) => {
+    const el = isFunction(leafletObject.value?.getElement) && leafletObject.value?.getElement()
+    if (!el) return
+    el.innerHTML = html
+})
+provide(
+    SetIconInjection,
+    (newIcon: Icon | DivIcon) =>
+        leafletObject.value?.setIcon && leafletObject.value.setIcon(newIcon),
+)
+
+const { methods } = setupMarker(props, leafletObject, emit)
+
+const eventHandlers: LeafletEventHandlerFnMap = {
+    move: debounce(methods.latLngSync),
+}
+
+onMounted(async () => {
+    const layerOptions = props.layerOptions || {}
+    if (shouldBlankIcon(useSlots())) {
+        layerOptions.icon = new DivIcon({ className: '' })
+    }
+    leafletObject.value = markRaw<Marker>(new Marker(props.latLng, layerOptions))
+
+    const { listeners } = remapEvents(useAttrs())
+
+    bindEventHandlers(leafletObject.value, listeners)
+    bindEventHandlers(leafletObject.value, eventHandlers)
+    propsBinder(methods, leafletObject.value, props)
+    addLayer({
+        ...props,
+        ...methods,
+        leafletObject: leafletObject.value,
+    })
+    ready.value = true
+    nextTick(() => emit('ready', leafletObject.value!))
+})
+
+onBeforeUnmount(() => cancelDebounces(eventHandlers))
+</script>
+
+<template>
+    <div v-if="ready" style="display: none">
+        <slot />
+    </div>
+</template>
+
+<style scoped></style>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export { default as LMap } from "./LMap.vue";
 export { default as LGridLayer } from "./LGridLayer.vue";
+export { default as LMarker } from "./LMarker.vue";
 export { default as LTileLayer } from "./LTileLayer.vue";

--- a/src/functions/marker.ts
+++ b/src/functions/marker.ts
@@ -6,6 +6,7 @@ import { type LayerEmits, type LayerProps, layerPropsDefaults, setupLayer } from
 const unrenderedContentTypes = ['Symbol(Comment)', 'Symbol(Text)']
 const unrenderedComponentNames = ['LTooltip', 'LPopup']
 
+// BREAKING CHANGES: pass layerOptions as Object instead of props
 export interface MarkerProps extends LayerProps<MarkerOptions> {
     latLng: LatLngExpression
 }
@@ -20,6 +21,7 @@ export type MarkerEmits = LayerEmits & {
     (event: 'update:lat-lng', value: LatLngExpression): void
 }
 
+// BREAKING CHANGES: setupMarker does not return options anymore
 export const setupMarker = (
     props: MarkerProps,
     leafletRef: Ref<Marker | undefined>,
@@ -34,10 +36,12 @@ export const setupMarker = (
             else leafletRef.value?.dragging?.disable()
         },
         latLngSync(
-            event: LeafletEvent & { latlng: LatLngExpression; oldLatLng: LatLngExpression },
+            event: LeafletEvent & { latlng?: LatLngExpression; oldLatLng?: LatLngExpression },
         ) {
-            emit('update:latLng', event.latlng)
-            emit('update:lat-lng', event.latlng)
+            if(event.latlng) {
+                emit('update:latLng', event.latlng)
+                emit('update:lat-lng', event.latlng)
+            }
         },
         setLatLng(newVal: LatLngExpression) {
             if (leafletRef.value) {

--- a/src/functions/marker.ts
+++ b/src/functions/marker.ts
@@ -1,0 +1,75 @@
+import type { LatLngExpression, LeafletEvent, Marker, MarkerOptions } from 'leaflet'
+import type { Ref, Slots } from 'vue'
+
+import { type LayerEmits, type LayerProps, layerPropsDefaults, setupLayer } from './layer'
+
+const unrenderedContentTypes = ['Symbol(Comment)', 'Symbol(Text)']
+const unrenderedComponentNames = ['LTooltip', 'LPopup']
+
+export interface MarkerProps extends LayerProps<MarkerOptions> {
+    latLng: LatLngExpression
+}
+
+export const markerPropsDefaults = {
+    ...layerPropsDefaults,
+}
+
+export type MarkerEmits = LayerEmits & {
+    (event: 'ready', marker: Marker): void
+    (event: 'update:latLng', value: LatLngExpression): void
+    (event: 'update:lat-lng', value: LatLngExpression): void
+}
+
+export const setupMarker = (
+    props: MarkerProps,
+    leafletRef: Ref<Marker | undefined>,
+    emit: MarkerEmits,
+) => {
+    const { methods: layerMethods } = setupLayer(props, leafletRef, emit)
+
+    const methods = {
+        ...layerMethods,
+        setDraggable(value: boolean) {
+            if (value) leafletRef.value?.dragging?.enable()
+            else leafletRef.value?.dragging?.disable()
+        },
+        latLngSync(
+            event: LeafletEvent & { latlng: LatLngExpression; oldLatLng: LatLngExpression },
+        ) {
+            emit('update:latLng', event.latlng)
+            emit('update:lat-lng', event.latlng)
+        },
+        setLatLng(newVal: LatLngExpression) {
+            if (leafletRef.value) {
+                const oldLatLng = leafletRef.value.getLatLng()
+                if (!oldLatLng || !oldLatLng.equals(newVal)) {
+                    leafletRef.value.setLatLng(newVal)
+                }
+            }
+        },
+    }
+
+    return { methods }
+}
+
+/**
+ * Determine whether the default Leaflet icon should be replaced with a blank div initially.
+ *
+ * @param {*} slots slots object returned by useSlots()
+ * @returns boolean
+ */
+export const shouldBlankIcon = (slots: Slots) => {
+    // If there is content within the <LMarker>, and it contains anything other than a
+    // tooltip for the marker, then the icon should be replaced with an empty div on
+    // creation so that Leaflet does not render its default icon momentarily before
+    // Vue mounts the inner content and vue-leaflet updates the marker with it.
+    // See https://github.com/vue-leaflet/vue-leaflet/issues/170
+    const slotContent = slots.default && slots.default()
+
+    return slotContent && slotContent.length && slotContent.some(contentIsRendered)
+}
+
+function contentIsRendered(el) {
+    if (unrenderedContentTypes.includes(el.type.toString())) return false
+    return !unrenderedComponentNames.includes(el.type.name)
+}

--- a/src/playground/main.ts
+++ b/src/playground/main.ts
@@ -43,10 +43,9 @@ const routes = [
         component: () => import("./views/ControlZoomDemo.vue"),
     },
     { path: "/geo-json", component: () => import("./views/GeoJsonDemo.vue") },
-    { path: "/icon", component: () => import("./views/IconDemo.vue") },
+    { path: "/icon", component: () => import("./views/IconDemo.vue") },*/
     { path: "/marker", component: () => import("./views/MarkerDemo.vue") },
-    { path: "/tile-layer", component: () => import("./views/TileLayerDemo.vue") },
-    {
+    /*{
         path: "/image-overlay",
         component: () => import("./views/ImageOverlayDemo.vue"),
     },

--- a/src/playground/views/MarkerDemo.vue
+++ b/src/playground/views/MarkerDemo.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { LMap, LTileLayer, LMarker } from '../../components'
+import type { LatLngTuple, MapOptions, MarkerOptions } from 'leaflet'
+
+const mapOptions: MapOptions = {
+    center: [47.41322, -1.219482],
+    zoom: 2,
+}
+const coordinates: LatLngTuple = [50, 50]
+const markerOptions: MarkerOptions = {
+    draggable: true
+}
+</script>
+
+<template>
+    <LMap ref="map" :map-options="mapOptions">
+        <LTileLayer
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            layer-type="base"
+            name="OpenStreetMap"
+        ></LTileLayer>
+
+        <LMarker :lat-lng="coordinates" :layer-options="markerOptions"></LMarker>
+    </LMap>
+</template>
+
+<style scoped></style>


### PR DESCRIPTION
LMarker component has been added. The functionality is the same as before. It now uses the composition API and composables. Playground has been updated. It comes with a few breaking changes:

- pass layerOptions as Object instead of props (LMarker)
- setupMarkerLayer does not return options anymore