### PR TITLE
feat(core): add LCircle and LCircleMarker components

### DIFF
--- a/src/components/LCircle.vue
+++ b/src/components/LCircle.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { Circle } from 'leaflet'
+import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
+
+import { AddLayerInjection } from '../types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { setupCircle, type CircleEmits, type CircleProps, circlePropsDefaults } from '../functions/circle.ts'
+
+const props = withDefaults(defineProps<CircleProps>(), circlePropsDefaults)
+const emit = defineEmits<CircleEmits>()
+
+const { ready, leafletObject } = useCircleMarker()
+defineExpose({ ready, leafletObject })
+
+function useCircleMarker() {
+    const leafletObject = ref<Circle>()
+    const ready = ref(false)
+
+    const addLayer = assertInject(AddLayerInjection)
+
+    const { options, methods } = setupCircle(props, leafletObject, emit)
+
+    onMounted(async () => {
+        leafletObject.value = markRaw<Circle>(new Circle(props.latLng, options))
+
+        const { listeners } = remapEvents(useAttrs())
+        leafletObject.value.on(listeners)
+
+        propsBinder(methods, leafletObject.value, props)
+
+        addLayer({
+            ...props,
+            ...methods,
+            leafletObject: leafletObject.value,
+        })
+        ready.value = true
+        nextTick(() => emit('ready', leafletObject.value!))
+    })
+
+    return { ready, leafletObject }
+}
+</script>
+
+<template>
+    <div v-if="ready" style="display: none">
+        <slot />
+    </div>
+</template>

--- a/src/components/LCircleMarker.vue
+++ b/src/components/LCircleMarker.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { CircleMarker } from 'leaflet'
+import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
+
+import {
+    type CircleMarkerEmits,
+    type CircleMarkerProps,
+    circleMarkerPropsDefaults,
+    setupCircleMarker,
+} from '../functions/circleMarker'
+import { AddLayerInjection } from '../types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '../utils.js'
+
+const props = withDefaults(defineProps<CircleMarkerProps>(), circleMarkerPropsDefaults)
+const emit = defineEmits<CircleMarkerEmits>()
+
+const { ready, leafletObject } = useCircleMarker()
+defineExpose({ ready, leafletObject })
+
+function useCircleMarker() {
+    const leafletObject = ref<CircleMarker>()
+    const ready = ref(false)
+
+    const addLayer = assertInject(AddLayerInjection)
+
+    const { options, methods } = setupCircleMarker(props, leafletObject, emit)
+
+    onMounted(async () => {
+        leafletObject.value = markRaw<CircleMarker>(new CircleMarker(props.latLng, options))
+
+        const { listeners } = remapEvents(useAttrs())
+        leafletObject.value.on(listeners)
+
+        propsBinder(methods, leafletObject.value, props)
+
+        addLayer({
+            ...props,
+            ...methods,
+            leafletObject: leafletObject.value,
+        })
+        ready.value = true
+        nextTick(() => emit('ready', leafletObject.value!))
+    })
+    return { leafletObject, ready }
+}
+</script>
+
+<template>
+    <div v-if="ready" style="display: none">
+        <slot />
+    </div>
+</template>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,5 @@
+export { default as LCircle } from './LCircle.vue'
+export { default as LCircleMarker } from './LCircleMarker.vue'
 export { default as LControl } from './LControl.vue'
 export { default as LControlAttribution } from './LControlAttribution.vue'
 export { default as LControlLayers } from './LControlLayers.vue'

--- a/src/functions/circle.ts
+++ b/src/functions/circle.ts
@@ -1,0 +1,44 @@
+import { Circle, type CircleOptions } from 'leaflet'
+
+import { propsToLeafletOptions } from '../utils'
+
+import {
+    type CircleMarkerEmits,
+    type CircleMarkerProps,
+    circleMarkerPropsDefaults,
+    setupCircleMarker,
+} from './circleMarker'
+import type { Ref } from 'vue'
+
+export interface CircleProps extends CircleMarkerProps<CircleOptions> {
+    /**
+     * Radius of the circle in meters.
+     */
+    radius: number
+}
+
+export const circlePropsDefaults = {
+    ...circleMarkerPropsDefaults,
+}
+
+export type CircleEmits = CircleMarkerEmits<Circle>
+
+export const setupCircle = (
+    props: CircleProps,
+    leafletRef: Ref<Circle | undefined>,
+    emit: CircleEmits,
+) => {
+    const { options: circleMarkerOptions, methods: circleMarkerMethods } = setupCircleMarker(
+        props,
+        leafletRef,
+        emit,
+    )
+
+    const options = propsToLeafletOptions<L.CircleOptions>(props, circleMarkerOptions)
+
+    const methods = {
+        ...circleMarkerMethods,
+    }
+
+    return { options, methods }
+}

--- a/src/functions/circleMarker.ts
+++ b/src/functions/circleMarker.ts
@@ -1,0 +1,46 @@
+import { propsToLeafletOptions } from '../utils'
+
+import { type PathEmits, type PathProps, pathPropsDefaults, setupPath as pathSetup } from './path'
+import { CircleMarker, type CircleMarkerOptions, type LatLngExpression } from 'leaflet'
+import type { Ref } from 'vue'
+
+export interface CircleMarkerProps<T extends CircleMarkerOptions = CircleMarkerOptions>
+    extends PathProps<T> {
+    /**
+     * Radius of the marker in pixels.
+     */
+    radius?: number
+    latLng: LatLngExpression
+}
+
+export const circleMarkerPropsDefaults = {
+    ...pathPropsDefaults,
+    // radius should be optional
+    options: () => ({ radius: 10 }),
+}
+
+export type CircleMarkerEmits<T extends CircleMarker = CircleMarker> = PathEmits & {
+    (event: 'ready', layer: T): void
+}
+
+export const setupCircleMarker = (
+    props: CircleMarkerProps,
+    leafletRef: Ref<CircleMarker | undefined>,
+    emit: CircleMarkerEmits,
+) => {
+    const { options: pathOptions, methods: pathMethods } = pathSetup(props, leafletRef, emit)
+
+    const options = propsToLeafletOptions<CircleMarkerOptions>(props, pathOptions)
+
+    const methods = {
+        ...pathMethods,
+        setRadius(radius: number) {
+            leafletRef.value?.setRadius(radius)
+        },
+        setLatLng(latLng: LatLngExpression) {
+            leafletRef.value?.setLatLng(latLng)
+        },
+    }
+
+    return { options, methods }
+}

--- a/src/playground/main.ts
+++ b/src/playground/main.ts
@@ -16,12 +16,12 @@ const routes = [
     /* {
         path: "/feature-group",
         component: () => import("./views/FeatureGroupDemo.vue"),
-    },
+    },*/
     { path: "/circle", component: () => import("./views/CircleDemo.vue") },
     {
         path: "/circle-marker",
         component: () => import("./views/CircleMarkerDemo.vue"),
-    },*/
+    },
     {
         path: "/control-attribution",
         component: () => import("./views/ControlAttributionDemo.vue"),

--- a/src/playground/views/CircleDemo.vue
+++ b/src/playground/views/CircleDemo.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { LCircle, LMap, LTileLayer } from '../../components'
+import { ref } from 'vue'
+
+const zoom = ref<number>(11)
+</script>
+
+<template>
+    <LMap ref="map" v-model:zoom="zoom" :center="[44.48865, 11.3317]">
+        <LTileLayer
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            layer-type="base"
+            name="OpenStreetMap"
+        ></LTileLayer>
+
+        <LCircle :lat-lng="[44.48865, 11.3317]" :radius="5000" color="green" />
+    </LMap>
+</template>
+
+<style></style>

--- a/src/playground/views/CircleMarkerDemo.vue
+++ b/src/playground/views/CircleMarkerDemo.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { LCircleMarker, LMap, LTileLayer } from '../../components'
+import { ref } from 'vue'
+
+const zoom = ref<number>(16)
+</script>
+
+<template>
+    <LMap ref="map" v-model:zoom="zoom" :center="[41.89026, 12.49238]">
+        <LTileLayer
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            layer-type="base"
+            name="OpenStreetMap"
+        ></LTileLayer>
+
+        <LCircleMarker :lat-lng="[41.89026, 12.49238]" :radius="50" />
+    </LMap>
+</template>
+
+<style></style>

--- a/src/playground/views/TooltipDemo.vue
+++ b/src/playground/views/TooltipDemo.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import {
+    LCircle,
+    LCircleMarker,
     LIcon,
     LMap,
     LMarker,
-    LTileLayer,
-    LTooltip,
     LPolygon,
     LPolyline,
     LRectangle,
+    LTileLayer,
+    LTooltip,
 } from '../../components'
 import type { LatLngExpression } from 'leaflet'
 import { ref } from 'vue'
@@ -82,13 +84,13 @@ const coordinates = ref<LatLngExpression>([41.75, -87.65])
             <LTooltip> Good day! Rectangle is my name!</LTooltip>
         </LRectangle>
 
-        <!--LCircle :lat-lng="[41.4329, -87.7327]" :radius="10000" color="green">
-        <LTooltip> Hi! I'm a green Circle!</LTooltip>
-    </LCircle-->
+        <LCircle :lat-lng="[41.4329, -87.7327]" :radius="10000" color="green">
+            <LTooltip> Hi! I'm a green Circle!</LTooltip>
+        </LCircle>
 
-        <!--LCircleMarker :lat-lng="[41.4329, -87.95]" :radius="20">
-        <LTooltip> Hi! You can call me Circle Marker!</LTooltip>
-    </LCircleMarker-->
+        <LCircleMarker :lat-lng="[41.4329, -87.95]" :radius="20">
+            <LTooltip> Hi! You can call me Circle Marker!</LTooltip>
+        </LCircleMarker>
     </LMap>
 </template>
 


### PR DESCRIPTION
LCircle and LCircleMarkercomponents have been added. The functionality is the same as before. It now uses the composition API and composables.
Playground has been updated.