### PR TITLE
fix(build): add version to installation details, and the build script is now independent of the package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,19 +63,19 @@ Let me now what you need!
 ## Installation
 
 ```bash
-pnpm add @maxel01/vue-leaflet leaflet
+pnpm add @maxel01/vue-leaflet leaflet@2.0.0-alpha
 ```
 
 or
 
 ```bash
-yarn add @maxel01/vue-leaflet leaflet
+yarn add @maxel01/vue-leaflet leaflet@2.0.0-alpha
 ```
 
 or
 
 ```bash
-npm i -D @maxel01/vue-leaflet leaflet
+npm i @maxel01/vue-leaflet leaflet@2.0.0-alpha
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "dev": "vite",
     "test": "vitest --coverage",
-    "build": "pnpm run type-check && pnpm run build-only",
+    "build": "vue-tsc --noEmit && vite build",
     "build-only": "vite build",
     "preview": "vite preview",
     "type-check": "vue-tsc --noEmit",


### PR DESCRIPTION
Installing leaflet will choose v1 instead of the v2-alpha. This will be fixed by specifying the version.

For maintainers: run build used pnpm before. It uses a package independent command instead. (resolves #24)

