### PR TITLE
test: add tests for `utils.ts` and basic tests for `LControlAttribution`

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -12,7 +12,7 @@ import skipFormatting from '@vue/eslint-config-prettier/skip-formatting'
 export default defineConfigWithVueTs(
     {
         name: '@vue-leaflet/vue-leaflet',
-        files: ['**/*.{ts,mts,tsx,vue}']
+        files: ['**/*.{ts,mts,tsx,vue}'],
     },
 
     globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**']),
@@ -21,14 +21,26 @@ export default defineConfigWithVueTs(
     vueTsConfigs.recommended,
 
     {
-        rules: {
-            '@typescript-eslint/no-unused-vars': ['error', {
-                argsIgnorePattern: '^_',
-                varsIgnorePattern: '^_'
-            }]
-        },
+
         ...pluginVitest.configs.recommended,
-        files: ['src/**/__tests__/*']
+        rules: {
+            '@typescript-eslint/no-unused-vars': [
+                'error',
+                {
+                    argsIgnorePattern: '^_',
+                    varsIgnorePattern: '^_',
+                },
+            ],
+            '@typescript-eslint/no-explicit-any': 'off',
+        },
+        files: [
+            'tests/**/*',
+            '**/*.test.ts',
+            '**/*.test.tsx',
+            '**/*.spec.ts',
+            '**/*.spec.tsx',
+            'src/**/__tests__/*',
+        ],
     },
-    skipFormatting
+    skipFormatting,
 )

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "release": "release-it"
   },
   "dependencies": {
+    "@vue/test-utils": "^2.4.6",
     "ts-debounce": "^4.0.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@vue/test-utils':
+        specifier: ^2.4.6
+        version: 2.4.6
       leaflet:
         specifier: ^2.0.0-alpha
         version: 2.0.0-alpha
@@ -799,6 +802,9 @@ packages:
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
 
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1256,6 +1262,9 @@ packages:
   '@vue/shared@3.5.17':
     resolution: {integrity: sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==}
 
+  '@vue/test-utils@2.4.6':
+    resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
+
   '@vue/tsconfig@0.7.0':
     resolution: {integrity: sha512-ku2uNz5MaZ9IerPPUyOHzyjhXoX2kVJaVf7hL315DC17vS6IiZRmmCPfggNbU16QTvM80+uYYy3eYJB59WCtvg==}
     peerDependencies:
@@ -1320,6 +1329,10 @@ packages:
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
+
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1553,6 +1566,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
@@ -1760,6 +1777,11 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  editorconfig@1.0.4:
+    resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
@@ -2327,6 +2349,15 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2562,6 +2593,10 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@9.0.1:
+    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2610,6 +2645,11 @@ packages:
   new-github-release-url@2.0.0:
     resolution: {integrity: sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
 
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
@@ -3439,6 +3479,9 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  vue-component-type-helpers@2.2.12:
+    resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
+
   vue-eslint-parser@10.2.0:
     resolution: {integrity: sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4245,6 +4288,8 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 24.2.0
 
+  '@one-ini/wasm@0.1.1': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -4789,6 +4834,11 @@ snapshots:
 
   '@vue/shared@3.5.17': {}
 
+  '@vue/test-utils@2.4.6':
+    dependencies:
+      js-beautify: 1.15.4
+      vue-component-type-helpers: 2.2.12
+
   '@vue/tsconfig@0.7.0(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3))':
     optionalDependencies:
       typescript: 5.8.3
@@ -4825,6 +4875,8 @@ snapshots:
     dependencies:
       jsonparse: 1.3.1
       through: 2.3.8
+
+  abbrev@2.0.0: {}
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -5055,6 +5107,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@10.0.1: {}
+
   compare-func@2.0.0:
     dependencies:
       array-ify: 1.0.0
@@ -5261,6 +5315,13 @@ snapshots:
       type-fest: 4.41.0
 
   eastasianwidth@0.2.0: {}
+
+  editorconfig@1.0.4:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.1
+      semver: 7.7.2
 
   emoji-regex-xs@1.0.0: {}
 
@@ -5889,6 +5950,16 @@ snapshots:
 
   jju@1.4.0: {}
 
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.4
+      glob: 10.4.5
+      js-cookie: 3.0.5
+      nopt: 7.2.1
+
+  js-cookie@3.0.5: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -6113,6 +6184,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@9.0.1:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
@@ -6149,6 +6224,10 @@ snapshots:
   new-github-release-url@2.0.0:
     dependencies:
       type-fest: 2.19.0
+
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
 
   normalize-package-data@6.0.2:
     dependencies:
@@ -7043,6 +7122,8 @@ snapshots:
       - yaml
 
   vscode-uri@3.1.0: {}
+
+  vue-component-type-helpers@2.2.12: {}
 
   vue-eslint-parser@10.2.0(eslint@9.31.0(jiti@2.4.2)):
     dependencies:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,6 +53,8 @@ export const propsBinder = (methods, leafletElement: Evented, props) => {
                     leafletElement[setMethodName](newVal)
                 },
             )
+        } else if (key !== 'options' && import.meta.env.vitest) {
+            console.warn(`No setter for '${key}'`)
         }
     }
 }

--- a/tests/unit/components/LControlAttribution.test.ts
+++ b/tests/unit/components/LControlAttribution.test.ts
@@ -1,0 +1,85 @@
+import { flushPromises, shallowMount } from '@vue/test-utils'
+import 'leaflet'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import LControlAttribution from '../../../src/components/LControlAttribution.vue'
+import { RegisterControlInjection } from '../../../src/types/injectionKeys'
+
+describe('LControlAttribution', () => {
+    const mockRegisterControl = vi.fn()
+    const getWrapper = async () => {
+        const wrapper = shallowMount(LControlAttribution, {
+            propsData: {
+                position: 'topright',
+                prefix: 'Hello there',
+            },
+            global: {
+                provide: {
+                    [RegisterControlInjection as symbol]: mockRegisterControl,
+                },
+            },
+        })
+        await flushPromises()
+
+        return wrapper
+    }
+
+    beforeEach(() => {
+        mockRegisterControl.mockReset()
+    })
+
+    it(`emits a ready event with the Leaflet object`, async () => {
+        const wrapper = await getWrapper()
+
+        expect(wrapper.emitted()).to.have.property('ready')
+        const readyEvent = wrapper.emitted('ready')
+        expect(readyEvent).to.have.length(1)
+        expect(readyEvent![0]).to.deep.equal([wrapper.vm.leafletObject])
+    })
+
+    it(`creates a Leaflet object with expected properties`, async () => {
+        const wrapper = await getWrapper()
+
+        expect(wrapper.vm.leafletObject).to.exist
+        const leafletObject = wrapper.vm.leafletObject!
+        expect(leafletObject!.options.prefix).to.equal('Hello there')
+        expect(leafletObject?.options.position).to.equal('topright')
+    })
+
+    it(`registers its Leaflet object`, async () => {
+        const wrapper = await getWrapper()
+
+        expect(mockRegisterControl).toHaveBeenCalledTimes(1)
+        expect(mockRegisterControl).toHaveBeenCalledWith({
+            leafletObject: wrapper.vm.leafletObject,
+        })
+    })
+
+    it(`updates the prefixt`, async () => {
+        const wrapper = await getWrapper()
+        expect(wrapper.vm.leafletObject?.options.prefix)
+
+        wrapper.setProps({ prefix: 'new prefix' })
+
+        await flushPromises()
+        expect(wrapper.vm.leafletObject?.options.prefix).to.equal('new prefix')
+    })
+
+    it(`updates the positiont`, async () => {
+        const wrapper = await getWrapper()
+
+        wrapper.setProps({ position: 'bottomleft' })
+
+        await flushPromises()
+        expect(wrapper.vm.leafletObject?.options.position).to.equal('bottomleft')
+    })
+
+    it(`removes itself from the map on unmount`, async () => {
+        const wrapper = await getWrapper()
+        const removeSpy = vi.spyOn(wrapper.vm.leafletObject!, 'remove')
+
+        wrapper.unmount()
+
+        expect(removeSpy).toBeCalledTimes(1)
+    })
+})

--- a/tests/unit/components/LControlAttribution.test.ts
+++ b/tests/unit/components/LControlAttribution.test.ts
@@ -1,85 +1,78 @@
-import { flushPromises, shallowMount } from '@vue/test-utils'
-import 'leaflet'
+import { flushPromises, shallowMount, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-
 import LControlAttribution from '../../../src/components/LControlAttribution.vue'
 import { RegisterControlInjection } from '../../../src/types/injectionKeys'
+import { Control } from 'leaflet'
+import { testComponentPropBindings, testEmitsReady, testRemovesOnUnmount } from './helper/tests'
+import { testComponentWatchBindings } from './helper/tststst'
 
-describe('LControlAttribution', () => {
-    const mockRegisterControl = vi.fn()
-    const getWrapper = async () => {
-        const wrapper = shallowMount(LControlAttribution, {
-            propsData: {
-                position: 'topright',
-                prefix: 'Hello there',
+const mockRegisterControl = vi.fn()
+
+const createWrapper = async (props = {}) => {
+    const wrapper = shallowMount(LControlAttribution, {
+        propsData: {
+            position: 'topright',
+            prefix: 'Hello there',
+            someProp: undefined,
+            ...props,
+        },
+        global: {
+            provide: {
+                [RegisterControlInjection as symbol]: mockRegisterControl,
             },
-            global: {
-                provide: {
-                    [RegisterControlInjection as symbol]: mockRegisterControl,
-                },
-            },
-        })
-        await flushPromises()
+        },
+    })
 
-        return wrapper
-    }
+    await flushPromises()
+    return wrapper
+}
 
+describe('LControlAttribution.vue', () => {
     beforeEach(() => {
         mockRegisterControl.mockReset()
     })
 
-    it(`emits a ready event with the Leaflet object`, async () => {
-        const wrapper = await getWrapper()
+    testEmitsReady(createWrapper)
 
-        expect(wrapper.emitted()).to.have.property('ready')
-        const readyEvent = wrapper.emitted('ready')
-        expect(readyEvent).to.have.length(1)
-        expect(readyEvent![0]).to.deep.equal([wrapper.vm.leafletObject])
+    it('creates a Leaflet Attribution control with correct options', async () => {
+        const wrapper = await createWrapper()
+        const obj = wrapper.vm.leafletObject as Control.Attribution
+
+        expect(obj).toBeDefined()
+        expect(obj.options.prefix).toBe('Hello there')
+        expect(obj.options.position).toBe('topright')
     })
 
-    it(`creates a Leaflet object with expected properties`, async () => {
-        const wrapper = await getWrapper()
-
-        expect(wrapper.vm.leafletObject).to.exist
-        const leafletObject = wrapper.vm.leafletObject!
-        expect(leafletObject!.options.prefix).to.equal('Hello there')
-        expect(leafletObject?.options.position).to.equal('topright')
-    })
-
-    it(`registers its Leaflet object`, async () => {
-        const wrapper = await getWrapper()
-
+    it('registers the control via injection', async () => {
+        const wrapper = await createWrapper()
         expect(mockRegisterControl).toHaveBeenCalledTimes(1)
         expect(mockRegisterControl).toHaveBeenCalledWith({
             leafletObject: wrapper.vm.leafletObject,
         })
     })
 
-    it(`updates the prefixt`, async () => {
-        const wrapper = await getWrapper()
-        expect(wrapper.vm.leafletObject?.options.prefix)
-
-        wrapper.setProps({ prefix: 'new prefix' })
-
-        await flushPromises()
-        expect(wrapper.vm.leafletObject?.options.prefix).to.equal('new prefix')
-    })
-
-    it(`updates the positiont`, async () => {
-        const wrapper = await getWrapper()
-
-        wrapper.setProps({ position: 'bottomleft' })
-
-        await flushPromises()
-        expect(wrapper.vm.leafletObject?.options.position).to.equal('bottomleft')
-    })
-
-    it(`removes itself from the map on unmount`, async () => {
-        const wrapper = await getWrapper()
-        const removeSpy = vi.spyOn(wrapper.vm.leafletObject!, 'remove')
-
-        wrapper.unmount()
-
-        expect(removeSpy).toBeCalledTimes(1)
-    })
+    testReactivePrefix(createWrapper)
+    testReactivePosition(createWrapper)
+    testRemovesOnUnmount(createWrapper)
+    testComponentPropBindings(createWrapper)
 })
+
+const testReactivePrefix = (getWrapper: () => Promise<VueWrapper<unknown>>) => {
+    it('reactively updates "prefix"', async () => {
+        const wrapper = await getWrapper()
+        await wrapper.setProps({ prefix: 'new prefix' })
+        await flushPromises()
+
+        expect(wrapper.vm.leafletObject?.options.prefix).toBe('new prefix')
+    })
+}
+
+const testReactivePosition = (getWrapper: () => Promise<VueWrapper<unknown>>) => {
+    it('reactively updates "position"', async () => {
+        const wrapper = await getWrapper()
+        await wrapper.setProps({ position: 'bottomleft' })
+        await flushPromises()
+
+        expect(wrapper.vm.leafletObject?.options.position).toBe('bottomleft')
+    })
+}

--- a/tests/unit/components/LControlAttribution.test.ts
+++ b/tests/unit/components/LControlAttribution.test.ts
@@ -4,7 +4,6 @@ import LControlAttribution from '../../../src/components/LControlAttribution.vue
 import { RegisterControlInjection } from '../../../src/types/injectionKeys'
 import { Control } from 'leaflet'
 import { testComponentPropBindings, testEmitsReady, testRemovesOnUnmount } from './helper/tests'
-import { testComponentWatchBindings } from './helper/tststst'
 
 const mockRegisterControl = vi.fn()
 
@@ -13,7 +12,6 @@ const createWrapper = async (props = {}) => {
         propsData: {
             position: 'topright',
             prefix: 'Hello there',
-            someProp: undefined,
             ...props,
         },
         global: {
@@ -33,31 +31,37 @@ describe('LControlAttribution.vue', () => {
     })
 
     testEmitsReady(createWrapper)
+    testComponentPropBindings(createWrapper)
+    testRemovesOnUnmount(createWrapper)
 
+    testCorrectInitialisation(createWrapper)
+    testControlRegistration(createWrapper)
+    testReactivePrefix(createWrapper)
+    testReactivePosition(createWrapper)
+})
+
+const testCorrectInitialisation = (getWrapper: () => Promise<VueWrapper<any>>) => {
     it('creates a Leaflet Attribution control with correct options', async () => {
-        const wrapper = await createWrapper()
+        const wrapper = await getWrapper()
         const obj = wrapper.vm.leafletObject as Control.Attribution
 
         expect(obj).toBeDefined()
         expect(obj.options.prefix).toBe('Hello there')
         expect(obj.options.position).toBe('topright')
     })
+}
 
+const testControlRegistration = (getWrapper: () => Promise<VueWrapper<any>>) => {
     it('registers the control via injection', async () => {
-        const wrapper = await createWrapper()
+        const wrapper = await getWrapper()
         expect(mockRegisterControl).toHaveBeenCalledTimes(1)
         expect(mockRegisterControl).toHaveBeenCalledWith({
             leafletObject: wrapper.vm.leafletObject,
         })
     })
+}
 
-    testReactivePrefix(createWrapper)
-    testReactivePosition(createWrapper)
-    testRemovesOnUnmount(createWrapper)
-    testComponentPropBindings(createWrapper)
-})
-
-const testReactivePrefix = (getWrapper: () => Promise<VueWrapper<unknown>>) => {
+const testReactivePrefix = (getWrapper: () => Promise<VueWrapper<any>>) => {
     it('reactively updates "prefix"', async () => {
         const wrapper = await getWrapper()
         await wrapper.setProps({ prefix: 'new prefix' })
@@ -67,7 +71,7 @@ const testReactivePrefix = (getWrapper: () => Promise<VueWrapper<unknown>>) => {
     })
 }
 
-const testReactivePosition = (getWrapper: () => Promise<VueWrapper<unknown>>) => {
+const testReactivePosition = (getWrapper: () => Promise<VueWrapper<any>>) => {
     it('reactively updates "position"', async () => {
         const wrapper = await getWrapper()
         await wrapper.setProps({ position: 'bottomleft' })

--- a/tests/unit/components/helper/tests.ts
+++ b/tests/unit/components/helper/tests.ts
@@ -1,0 +1,31 @@
+import { expect, vi, it, describe } from 'vitest'
+import type { VueWrapper } from '@vue/test-utils'
+
+export const testEmitsReady = (getWrapper: () => Promise<VueWrapper<any>>) => {
+    it('emits "ready" with the Leaflet object', async () => {
+        const wrapper = await getWrapper()
+        const readyEvent = wrapper.emitted('ready')
+
+        expect(readyEvent).toHaveLength(1)
+        expect(readyEvent![0][0]).toBe(wrapper.vm.leafletObject)
+    })
+}
+
+export const testRemovesOnUnmount = (getWrapper: () => Promise<VueWrapper<any>>) => {
+    it('removes the leafletObject on unmount', async () => {
+        const wrapper = await getWrapper()
+        const removeSpy = vi.spyOn(wrapper.vm.leafletObject!, 'remove')
+
+        wrapper.unmount()
+        expect(removeSpy).toHaveBeenCalledOnce()
+    })
+}
+
+export function testComponentPropBindings(getWrapper: () => Promise<VueWrapper<unknown>>) {
+    it('registers watch for each prop with matching setter', async () => {
+        const consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        await getWrapper()
+        expect(consoleWarnMock).not.toHaveBeenCalled()
+        consoleWarnMock.mockRestore()
+    })
+}

--- a/tests/unit/components/helper/tests.ts
+++ b/tests/unit/components/helper/tests.ts
@@ -1,4 +1,4 @@
-import { expect, vi, it, describe } from 'vitest'
+import { expect, it, vi } from 'vitest'
 import type { VueWrapper } from '@vue/test-utils'
 
 export const testEmitsReady = (getWrapper: () => Promise<VueWrapper<any>>) => {
@@ -21,7 +21,7 @@ export const testRemovesOnUnmount = (getWrapper: () => Promise<VueWrapper<any>>)
     })
 }
 
-export function testComponentPropBindings(getWrapper: () => Promise<VueWrapper<unknown>>) {
+export function testComponentPropBindings(getWrapper: () => Promise<VueWrapper<any>>) {
     it('registers watch for each prop with matching setter', async () => {
         const consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {})
         await getWrapper()

--- a/tests/unit/utils/assertInject.integration.test.ts
+++ b/tests/unit/utils/assertInject.integration.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h, InjectionKey, provide } from 'vue'
+import { mount } from '@vue/test-utils'
+import { assertInject } from '../../../src/utils'
+
+const MyKey: InjectionKey<string> = Symbol('MyKey')
+
+const Provider = defineComponent({
+    setup(_, { slots }) {
+        provide(MyKey, 'injectedValue')
+        return () => h('div', slots.default?.())
+    },
+})
+
+const Consumer = defineComponent({
+    setup() {
+        const value = assertInject(MyKey)
+        return () => h('span', value)
+    },
+})
+
+describe('assertInject (integration)', () => {
+    it('injects value from provider', () => {
+        const wrapper = mount(Provider, {
+            slots: {
+                default: () => h(Consumer),
+            },
+        })
+
+        expect(wrapper.html()).toContain('injectedValue')
+    })
+
+    it('throws if value is not provided', () => {
+        const wrapperFn = () => mount(Consumer)
+        expect(wrapperFn).toThrowError('Attempt to inject MyKey before it was provided.')
+    })
+})

--- a/tests/unit/utils/assertInject.unit.test.ts
+++ b/tests/unit/utils/assertInject.unit.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { inject, InjectionKey } from 'vue'
+import { assertInject } from '../../../src/utils'
+
+const mockedInject = inject as unknown as ReturnType<typeof vi.fn>
+// Mock Vue's inject
+vi.mock('vue', async () => {
+    const actual = await vi.importActual<typeof import('vue')>('vue')
+    return {
+        ...actual,
+        inject: vi.fn(),
+    }
+})
+
+describe('assertInject (unit)', () => {
+    beforeEach(() => {
+        mockedInject.mockReset()
+    })
+
+    it('returns the injected value when defined', () => {
+        const key: InjectionKey<string> = { description: 'myKey' } as InjectionKey<string>
+        mockedInject.mockReturnValue('hello')
+
+        const result = assertInject(key)
+        expect(result).toBe('hello')
+        expect(mockedInject).toHaveBeenCalledWith(key)
+    })
+
+    it('throws an error when injected value is undefined', () => {
+        const key: InjectionKey<string> = { description: 'missingKey' } as InjectionKey<string>
+        mockedInject.mockReturnValue(undefined)
+
+        expect(() => assertInject(key)).toThrowError(
+            'Attempt to inject missingKey before it was provided.',
+        )
+    })
+})

--- a/tests/unit/utils/bindEventHandlers.test.ts
+++ b/tests/unit/utils/bindEventHandlers.test.ts
@@ -1,0 +1,46 @@
+import { bindEventHandlers } from '../../../src/utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Evented, LeafletEventHandlerFnMap } from 'leaflet'
+
+describe('bindEventHandlers', () => {
+    let mockLeafletObject: Evented
+
+    beforeEach(() => {
+        mockLeafletObject = {
+            on: vi.fn(),
+        } as unknown as Evented
+    })
+
+    it('binds all event handlers correctly', () => {
+        const handlers = {
+            click: vi.fn(),
+            mouseover: vi.fn(),
+        }
+
+        bindEventHandlers(mockLeafletObject, handlers)
+
+        expect(mockLeafletObject.on).toHaveBeenCalledTimes(2)
+        expect(mockLeafletObject.on).toHaveBeenCalledWith('click', handlers.click)
+        expect(mockLeafletObject.on).toHaveBeenCalledWith('mouseover', handlers.mouseover)
+    })
+
+    it('does not bind any events if the handler map is empty', () => {
+        const handlers = {}
+
+        bindEventHandlers(mockLeafletObject, handlers)
+
+        expect(mockLeafletObject.on).not.toHaveBeenCalled()
+    })
+
+    it('binds undefined or null handlers', () => {
+        const handlers = {
+            click: undefined,
+            zoom: null,
+        } as LeafletEventHandlerFnMap
+
+        bindEventHandlers(mockLeafletObject, handlers)
+
+        expect(mockLeafletObject.on).toHaveBeenCalledWith('click', undefined)
+        expect(mockLeafletObject.on).toHaveBeenCalledWith('zoom', null)
+    })
+})

--- a/tests/unit/utils/cancelDebounces.test.ts
+++ b/tests/unit/utils/cancelDebounces.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+import { cancelDebounces } from '../../../src/utils'
+import type { LeafletEventHandlerFnMap } from 'leaflet'
+
+// Helper type for handlers with cancel method
+type CancellableHandler = {
+    (): void
+    cancel: () => void
+}
+
+describe('cancelDebounces', () => {
+    it('calls cancel on all handlers that have a cancel method', () => {
+        const cancelClick = vi.fn()
+        const cancelZoom = vi.fn()
+
+        const clickHandler: CancellableHandler = Object.assign(() => {}, { cancel: cancelClick })
+        const zoomHandler: CancellableHandler = Object.assign(() => {}, { cancel: cancelZoom })
+
+        const handlers: LeafletEventHandlerFnMap = {
+            click: clickHandler,
+            zoom: zoomHandler,
+        }
+
+        cancelDebounces(handlers)
+
+        expect(cancelClick).toHaveBeenCalledOnce()
+        expect(cancelZoom).toHaveBeenCalledOnce()
+    })
+
+    it('does not throw if handlers do not have cancel method', () => {
+        const handlers: LeafletEventHandlerFnMap = {
+            click: () => {},
+            zoom: () => {},
+        }
+
+        expect(() => cancelDebounces(handlers)).not.toThrow()
+    })
+
+    it('skips undefined or null handlers', () => {
+        const handlers: LeafletEventHandlerFnMap = {
+            click: undefined,
+            zoom: null,
+        }
+
+        expect(() => cancelDebounces(handlers)).not.toThrow()
+    })
+
+    it('ignores non-function cancel properties', () => {
+        const handler = Object.assign(() => {}, { cancel: 'notAFunction' })
+
+        const handlers: LeafletEventHandlerFnMap = {
+            move: handler,
+        }
+
+        expect(() => cancelDebounces(handlers)).not.toThrow()
+    })
+})

--- a/tests/unit/utils/capitalizeFirstLetter.test.ts
+++ b/tests/unit/utils/capitalizeFirstLetter.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { capitalizeFirstLetter } from '../../../src/utils'
+
+describe('capitalizeFirstLetter', () => {
+    it('returns empty string given empty string', () => {
+        const result = capitalizeFirstLetter('')
+
+        expect(result).to.be.empty
+    })
+
+    it('capitalizes the first letter of a string starting with a letter, and changes nothing else', () => {
+        const result = capitalizeFirstLetter('this IS a String!')
+
+        expect(result).to.equal('This IS a String!')
+    })
+
+    it('returns a string unchanged when not starting with a letter', () => {
+        const result = capitalizeFirstLetter('42 is the answer')
+
+        expect(result).to.equal('42 is the answer')
+    })
+})

--- a/tests/unit/utils/isFunction.test.ts
+++ b/tests/unit/utils/isFunction.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { isFunction } from '../../../src/utils'
+
+describe('isFunction', () => {
+    it('returns true for regular functions', () => {
+        expect(isFunction(function () {})).toBe(true)
+    })
+
+    it('returns true for arrow functions', () => {
+        expect(isFunction(() => {})).toBe(true)
+    })
+
+    it('returns true for async functions', () => {
+        expect(isFunction(async () => {})).toBe(true)
+    })
+
+    it('returns true for class constructors', () => {
+        class MyClass {}
+        expect(isFunction(MyClass)).toBe(true)
+    })
+
+    it('returns false for objects', () => {
+        expect(isFunction({})).toBe(false)
+    })
+
+    it('returns false for arrays', () => {
+        expect(isFunction([])).toBe(false)
+    })
+
+    it('returns false for strings', () => {
+        expect(isFunction('hello')).toBe(false)
+    })
+
+    it('returns false for numbers', () => {
+        expect(isFunction(42)).toBe(false)
+    })
+
+    it('returns false for null', () => {
+        expect(isFunction(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+        expect(isFunction(undefined)).toBe(false)
+    })
+
+    it('returns false for boolean values', () => {
+        expect(isFunction(true)).toBe(false)
+        expect(isFunction(false)).toBe(false)
+    })
+
+    it('returns true for Proxy-wrapped functions', () => {
+        const fn = () => {}
+        const proxy = new Proxy(fn, {})
+        expect(isFunction(proxy)).toBe(true)
+    })
+})

--- a/tests/unit/utils/propsBinder.test.ts
+++ b/tests/unit/utils/propsBinder.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import { propsBinder } from '../../../src/utils'
+import { nextTick, reactive } from 'vue'
+
+describe('propsBinder', () => {
+    it('should bind props to methods object using watchers', async () => {
+        const methods = {
+            setColor: vi.fn(),
+        }
+
+        const leafletElement = {}
+        const props = reactive({
+            color: 'red',
+        })
+
+        propsBinder(methods, leafletElement, props)
+
+        props.color = 'blue'
+        await nextTick()
+
+        expect(methods.setColor).toHaveBeenCalledWith('blue', 'red')
+    })
+
+    it('should bind props to leafletElement if method not in methods object', async () => {
+        const methods = {}
+        const leafletElement = {
+            setOpacity: vi.fn(),
+        }
+
+        const props = reactive({
+            opacity: 0.5,
+        })
+
+        propsBinder(methods, leafletElement, props)
+
+        props.opacity = 0.8
+        await nextTick()
+
+        expect(leafletElement.setOpacity).toHaveBeenCalledWith(0.8)
+    })
+
+    it('should not bind props if no matching setMethod exists', async () => {
+        const methods = {}
+        const leafletElement = {
+            setOpacity: vi.fn(),
+        }
+        const props = reactive({
+            weight: 3,
+        })
+
+        propsBinder(methods, leafletElement, props)
+
+        props.weight = 5
+        await nextTick()
+
+        expect(leafletElement.setOpacity).toBeCalledTimes(0)
+    })
+})

--- a/tests/unit/utils/propsBinder.test.ts
+++ b/tests/unit/utils/propsBinder.test.ts
@@ -40,6 +40,7 @@ describe('propsBinder', () => {
     })
 
     it('should not bind props if no matching setMethod exists', async () => {
+        const consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {})
         const methods = {}
         const leafletElement = {
             setOpacity: vi.fn(),
@@ -53,6 +54,7 @@ describe('propsBinder', () => {
         props.weight = 5
         await nextTick()
 
-        expect(leafletElement.setOpacity).toBeCalledTimes(0)
+        expect(leafletElement.setOpacity).not.toHaveBeenCalled()
+        expect(consoleWarnMock).toHaveBeenCalledOnce()
     })
 })

--- a/tests/unit/utils/propsToLeafletOptions.test.ts
+++ b/tests/unit/utils/propsToLeafletOptions.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { propsToLeafletOptions } from '../../../src/utils'
+
+interface ComponentProps {
+    options?: object
+    color?: string
+    weight?: number
+    opacity?: number
+    [key: string]: unknown
+}
+
+describe('propsToLeafletOptions', () => {
+    it('should merge props into baseOptions', () => {
+        const props: ComponentProps = {
+            color: 'red',
+            weight: 5,
+        }
+
+        const baseOptions = {
+            opacity: 0.8,
+        }
+
+        const result = propsToLeafletOptions<ComponentProps>(props, baseOptions)
+
+        expect(result).toEqual({
+            color: 'red',
+            weight: 5,
+            opacity: 0.8,
+        })
+    })
+
+    it('should ignore undefined values in props', () => {
+        const props: ComponentProps = {
+            color: 'blue',
+            weight: undefined,
+        }
+
+        const baseOptions = {
+            color: 'blue',
+            opacity: 0.5,
+        }
+
+        const result = propsToLeafletOptions<ComponentProps>(props, baseOptions)
+
+        expect(result).toEqual({
+            weight: undefined,
+            color: 'blue',
+            opacity: 0.5,
+        })
+    })
+
+    it('should ignore the "options" key in props', () => {
+        const props: ComponentProps = {
+            options: { some: 'value' },
+            color: 'green',
+        }
+
+        const baseOptions = {
+            weight: 2,
+        }
+
+        const result = propsToLeafletOptions<ComponentProps>(props, baseOptions)
+
+        expect(result).toEqual({
+            color: 'green',
+            weight: 2,
+        })
+    })
+
+    it('should work with empty baseOptions', () => {
+        const props: ComponentProps = {
+            color: 'yellow',
+            weight: 1,
+        }
+
+        const result = propsToLeafletOptions<ComponentProps>(props)
+
+        expect(result).toEqual({
+            color: 'yellow',
+            weight: 1,
+        })
+    })
+
+    it('should return baseOptions unchanged if props are empty', () => {
+        const props: ComponentProps = {}
+
+        const baseOptions = {
+            color: 'purple',
+            weight: 4,
+        }
+
+        const result = propsToLeafletOptions<ComponentProps>(props, baseOptions)
+
+        expect(result).toEqual(baseOptions)
+    })
+
+    it('should overwrite baseOptions if defined in props', () => {
+        const props: ComponentProps = {
+            color: 'red',
+        }
+
+        const baseOptions = {
+            color: 'purple',
+            weight: 4,
+        }
+
+        const result = propsToLeafletOptions<ComponentProps>(props, baseOptions)
+
+        expect(result).toEqual({
+            color: 'red',
+            weight: 4,
+        })
+    })
+})

--- a/tests/unit/utils/provideLeafletWrapper.test.ts
+++ b/tests/unit/utils/provideLeafletWrapper.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest'
+import { provideLeafletWrapper, updateLeafletWrapper } from '../../../src/utils'
+import { inject, defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+
+const testKey = Symbol('testMethod')
+
+describe('provideLeafletWrapper', () => {
+    it('should provide a default wrapper that logs a warning', () => {
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        const TestComponent = defineComponent({
+            setup() {
+                const wrapper = provideLeafletWrapper(testKey)
+                wrapper('arg1', 'arg2')
+                return () => h('div')
+            },
+        })
+
+        mount(TestComponent)
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+            'Method Symbol(testMethod) has been invoked without being replaced'
+        )
+        consoleWarnSpy.mockRestore()
+    })
+
+    it('should allow updating the wrapper function', () => {
+        const mockFn = vi.fn()
+
+        const TestComponent = defineComponent({
+            setup() {
+                const wrapper = provideLeafletWrapper(testKey)
+                updateLeafletWrapper(wrapper, mockFn)
+                wrapper('foo', 'bar')
+                return () => h('div')
+            },
+        })
+
+        mount(TestComponent)
+        expect(mockFn).toHaveBeenCalledWith('foo', 'bar')
+    })
+
+    it('should inject the wrapper correctly', () => {
+        const mockFn = vi.fn()
+
+        const ProviderComponent = defineComponent({
+            setup(_, { slots }) {
+                const wrapper = provideLeafletWrapper(testKey)
+                updateLeafletWrapper(wrapper, mockFn)
+                return () => h('div', slots.default?.())
+            },
+        })
+
+        const ConsumerComponent = defineComponent({
+            setup() {
+                const injected = inject(testKey) as (...args: any[]) => void
+                injected('hello')
+                return () => h('div')
+            },
+        })
+
+        mount(ProviderComponent, {
+            slots: {
+                default: () => h(ConsumerComponent),
+            },
+        })
+
+        expect(mockFn).toHaveBeenCalledWith('hello')
+    })
+})

--- a/tests/unit/utils/remapEvents.test.ts
+++ b/tests/unit/utils/remapEvents.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { remapEvents } from '../../../src/utils'
+
+describe('remapEvents', () => {
+    it('should separate event listeners from attributes', () => {
+        const input = {
+            onClick: () => {},
+            onMouseover: () => {},
+            title: 'Hello',
+            id: 'marker-1',
+        }
+
+        const { listeners, attrs } = remapEvents(input)
+
+        expect(Object.keys(listeners)).toEqual(['click', 'mouseover'])
+        expect(Object.keys(attrs)).toEqual(['title', 'id'])
+    })
+
+    it('should ignore onUpdate* and onReady as listeners', () => {
+        const input = {
+            onClick: () => {},
+            onUpdateModelValue: () => {},
+            onReady: () => {},
+            name: 'Test',
+        }
+
+        const { listeners, attrs } = remapEvents(input)
+
+        expect(Object.keys(listeners)).toEqual(['click'])
+        expect(Object.keys(attrs)).toEqual(['onUpdateModelValue', 'onReady', 'name'])
+    })
+
+    it('should handle empty input gracefully', () => {
+        const { listeners, attrs } = remapEvents({})
+
+        expect(listeners).toEqual({})
+        expect(attrs).toEqual({})
+    })
+
+    it('should preserve original values', () => {
+        const clickHandler = () => {}
+        const input = {
+            onClick: clickHandler,
+            label: 'Test',
+        }
+
+        const { listeners, attrs } = remapEvents(input)
+
+        expect(listeners.click).toBe(clickHandler)
+        expect(attrs.label).toBe('Test')
+    })
+})


### PR DESCRIPTION
This PR integrates the tests from the previous repository and adds nearly all test cases for `utils.ts.`
While component tests are not yet implemented, the `LControlAttribution` test serves as an example of how such tests could be structured.