### PR TITLE
chore: fix some TypeScript-related errors in utils.ts

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -12,6 +12,15 @@ import skipFormatting from '@vue/eslint-config-prettier/skip-formatting'
 export default defineConfigWithVueTs(
     {
         name: '@vue-leaflet/vue-leaflet',
+        rules: {
+            '@typescript-eslint/no-unused-vars': [
+                'error',
+                {
+                    argsIgnorePattern: '^_',
+                    varsIgnorePattern: '^_',
+                },
+            ],
+        },
         files: ['**/*.{ts,mts,tsx,vue}'],
     },
 
@@ -19,6 +28,7 @@ export default defineConfigWithVueTs(
 
     pluginVue.configs['flat/essential'],
     vueTsConfigs.recommended,
+
 
     {
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -17,11 +17,11 @@ export default defineConfigWithVueTs(
                 'error',
                 {
                     argsIgnorePattern: '^_',
-                    varsIgnorePattern: '^_',
-                },
-            ],
+                    varsIgnorePattern: '^_'
+                }
+            ]
         },
-        files: ['**/*.{ts,mts,tsx,vue}'],
+        files: ['**/*.{ts,mts,tsx,vue}']
     },
 
     globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**']),
@@ -29,19 +29,17 @@ export default defineConfigWithVueTs(
     pluginVue.configs['flat/essential'],
     vueTsConfigs.recommended,
 
-
     {
-
         ...pluginVitest.configs.recommended,
         rules: {
             '@typescript-eslint/no-unused-vars': [
                 'error',
                 {
                     argsIgnorePattern: '^_',
-                    varsIgnorePattern: '^_',
-                },
+                    varsIgnorePattern: '^_'
+                }
             ],
-            '@typescript-eslint/no-explicit-any': 'off',
+            '@typescript-eslint/no-explicit-any': 'off'
         },
         files: [
             'tests/**/*',
@@ -49,8 +47,8 @@ export default defineConfigWithVueTs(
             '**/*.test.tsx',
             '**/*.spec.ts',
             '**/*.spec.tsx',
-            'src/**/__tests__/*',
-        ],
+            'src/**/__tests__/*'
+        ]
     },
-    skipFormatting,
+    skipFormatting
 )

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,11 +12,11 @@ export declare type ListenersAndAttrs = {
 /**
  * A generalized interface/type to type-hint whatever may be defined in a class/object.
  */
-export declare type PropertyMap = {
+export type PropertyMap = {
     [propertyName: string]: unknown,
 }
 
-export declare type FunctionMap = Record<string, ((...args: unknown[]) => unknown) | undefined>
+export type FunctionMap = Record<string, ((...args: unknown[]) => unknown) | undefined>
 
 export type LeafletWrapper = {
     (...args: unknown[]): unknown

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,9 +17,7 @@ export declare type PropertyMap = {
     [propertyName: string]: any,
 }
 
-declare type FunctionMap = {
-    [functionName: string]: Function | undefined,
-}
+export declare type FunctionMap = Record<string, Function | undefined>;
 
 export const bindEventHandlers = (
     leafletObject: Evented,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,10 @@ export declare type PropertyMap = {
     [propertyName: string]: any,
 }
 
+declare type FunctionMap = {
+    [functionName: string]: Function | undefined,
+}
+
 export const bindEventHandlers = (
     leafletObject: Evented,
     eventHandlers: LeafletEventHandlerFnMap,
@@ -43,7 +47,7 @@ export const capitalizeFirstLetter = (s: string) => {
 
 export const isFunction = (x: unknown) => typeof x === 'function'
 
-export const propsBinder = (methods: PropertyMap, leafletElement: Evented, props) => {
+export const propsBinder = (methods: Readonly<FunctionMap>, leafletElement: Evented, props: Readonly<PropertyMap>) => {
     const leafletElementPropMap = leafletElement as PropertyMap;
     for (const key in props) {
         const setMethodName = 'set' + capitalizeFirstLetter(key)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,7 +100,8 @@ export const propsToLeafletOptions = <T extends object>(
 }
 
 export const remapEvents = (contextAttrs: Record<string, unknown>): ListenersAndAttrs => {
-    const listeners: LeafletEventHandlerFnMap = {}
+    // note: additional Leaflet extensions may have their custom event handlers, so we will be general here and type-hint it as FunctionMap
+    const listeners: FunctionMap = {}
     const attrs: Record<string, unknown> = {}
     for (const attrName in contextAttrs) {
         if (
@@ -109,7 +110,11 @@ export const remapEvents = (contextAttrs: Record<string, unknown>): ListenersAnd
             attrName !== 'onReady'
         ) {
             const eventName = attrName.slice(2).toLocaleLowerCase()
-            listeners[eventName] = contextAttrs[attrName]
+            const eventHandler = contextAttrs[attrName]
+            if (isFunction(eventHandler)) {
+                // note: if handler is undefined, then might as well don't tell Leaflet about it
+                listeners[eventName] = eventHandler
+            }
         } else {
             attrs[attrName] = contextAttrs[attrName]
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export const bindEventHandlers = (
 
 export const cancelDebounces = (handlerMethods: LeafletEventHandlerFnMap) => {
     for (const [, eventHandler] of Object.entries(handlerMethods)) {
-        if (eventHandler && isFunction(eventHandler.cancel)) {
+        if (isFunction(eventHandler?.cancel)) {
             eventHandler.cancel()
         }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,12 @@ export declare type PropertyMap = {
 
 export declare type FunctionMap = Record<string, ((...args: unknown[]) => unknown) | undefined>
 
+export type LeafletWrapper = {
+    (...args: unknown[]): unknown
+    wrapped: Ref<(...args: unknown[]) => unknown>
+};
+
+
 export const bindEventHandlers = (
     leafletObject: Evented,
     eventHandlers: LeafletEventHandlerFnMap
@@ -139,12 +145,6 @@ export const resetWebpackIcon = async (Icon) => {
         shadowUrl: modules[2].default
     })
 }
-
-type LeafletWrapper = {
-    (...args: unknown[]): unknown;
-    wrapped: Ref<(...args: unknown[]) => unknown>;
-};
-
 
 /**
  * Wrap a placeholder function and provide it with the given name.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,16 +13,15 @@ export const bindEventHandlers = (
     leafletObject: Evented,
     eventHandlers: LeafletEventHandlerFnMap,
 ): void => {
-    for (const eventName of Object.keys(eventHandlers)) {
-        leafletObject.on(eventName, eventHandlers[eventName])
+    for (const [eventName, eventHandler] of Object.entries(eventHandlers)) {
+        leafletObject.on(eventName, eventHandler)
     }
 }
 
 export const cancelDebounces = (handlerMethods: LeafletEventHandlerFnMap) => {
-    for (const name of Object.keys(handlerMethods)) {
-        const handler = handlerMethods[name]
-        if (handler && isFunction(handler.cancel)) {
-            handler.cancel()
+    for (const [, eventHandler] of Object.entries(handlerMethods)) {
+        if (eventHandler && isFunction(eventHandler.cancel)) {
+            eventHandler.cancel()
         }
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,6 +47,12 @@ export const capitalizeFirstLetter = (s: string) => {
 
 export const isFunction = (x: unknown) => typeof x === 'function'
 
+/**
+ * Sets up listeners for Vue component prop changes, so that we may correctly call the correct Leaflet on-change event handlers.
+ * @param methods
+ * @param leafletElement
+ * @param props the relevant Vue component props
+ */
 export const propsBinder = (methods: Readonly<FunctionMap>, leafletElement: Evented, props: Readonly<PropertyMap>) => {
     const leafletElementPropMap = leafletElement as PropertyMap;
     for (const key in props) {


### PR DESCRIPTION
See #29 for related work.

Ultimately, fixing TypeScript errors require a very deep understanding of the code base, and this cannot be rushed. So, the strategy is to fix them one by one when we come across them, and when we understand what should be happening.

This PR should be uncontroversial; the behavior of `utils.ts` remains the same as before the PR.