### PR TITLE
chore: use alias imports

### DIFF
--- a/alias.config.js
+++ b/alias.config.js
@@ -1,0 +1,6 @@
+import { fileURLToPath, URL } from 'node:url'
+
+export const alias = {
+    '@/maxel01/vue-leaflet': fileURLToPath(new URL('./src/lib', import.meta.url)),
+    '@': fileURLToPath(new URL('./src', import.meta.url))
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitepress'
+import { alias } from '../../alias.config'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -6,6 +7,11 @@ export default defineConfig({
     description: "Documentation for the Vue Leaflet module",
     head: [['link', { rel: 'icon', href: '/favicon.ico' }]],
     base: '/',
+    vite: {
+        resolve: {
+            alias
+        },
+    },
     themeConfig: {
         // https://vitepress.dev/reference/default-theme-config
         nav: [

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -5,7 +5,7 @@ import './custom.css'
 export default {
     extends: DefaultTheme,
     enhanceApp({ app }) {
-        const components = import.meta.glob('../../../src/playground/views/*.vue', { eager: true })
+        const components = import.meta.glob('@/playground/views/*.vue', { eager: true })
         for (const [path, module] of Object.entries(components)) {
             const name = path
                 .split('/')

--- a/docs/scripts/test.js
+++ b/docs/scripts/test.js
@@ -1,8 +1,10 @@
 import { parse } from 'vue-docgen-api'
 import propOriginHandler from './handler.js'
+import { alias } from '../../alias.config.js'
 
 
 const result = await parse('./src/components/LCircleMarker.vue', {
+    alias,
     addScriptHandlers: [
         propOriginHandler
     ],

--- a/src/components/LCircle.vue
+++ b/src/components/LCircle.vue
@@ -3,13 +3,13 @@ import { Circle } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 
 import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 import {
     type CircleEmits,
     type CircleProps,
     circlePropsDefaults,
     setupCircle
-} from '../functions/circle.ts'
+} from '../functions/circle'
 
 /**
  * > Draw a path in the shape of a circle around a center positioned at `latLng` coordinates.

--- a/src/components/LCircle.vue
+++ b/src/components/LCircle.vue
@@ -2,14 +2,14 @@
 import { Circle } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 
-import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+import { AddLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 import {
     type CircleEmits,
     type CircleProps,
     circlePropsDefaults,
     setupCircle
-} from '../functions/circle'
+} from '@/functions/circle'
 
 /**
  * > Draw a path in the shape of a circle around a center positioned at `latLng` coordinates.

--- a/src/components/LCircleMarker.vue
+++ b/src/components/LCircleMarker.vue
@@ -9,7 +9,7 @@ import {
     setupCircleMarker
 } from '../functions/circleMarker'
 import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 
 /**
  * > A circle of a fixed size with radius specified in pixels.

--- a/src/components/LCircleMarker.vue
+++ b/src/components/LCircleMarker.vue
@@ -7,9 +7,9 @@ import {
     type CircleMarkerProps,
     circleMarkerPropsDefaults,
     setupCircleMarker
-} from '../functions/circleMarker'
-import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+} from '@/functions/circleMarker'
+import { AddLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 
 /**
  * > A circle of a fixed size with radius specified in pixels.

--- a/src/components/LControl.vue
+++ b/src/components/LControl.vue
@@ -9,7 +9,7 @@ import {
     setupControl
 } from '../functions/control'
 import { RegisterControlInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder } from '../utils.js'
+import { assertInject, propsBinder } from '../utils'
 
 /**
  * > Base component for implementing map controls. Handles positioning. All other controls extend from this component.

--- a/src/components/LControl.vue
+++ b/src/components/LControl.vue
@@ -7,9 +7,9 @@ import {
     type ControlProps,
     controlPropsDefaults,
     setupControl
-} from '../functions/control'
-import { RegisterControlInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder } from '../utils'
+} from '@/functions/control'
+import { RegisterControlInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder } from '@/utils'
 
 /**
  * > Base component for implementing map controls. Handles positioning. All other controls extend from this component.

--- a/src/components/LControlAttribution.vue
+++ b/src/components/LControlAttribution.vue
@@ -7,9 +7,9 @@ import {
     type ControlAttributionProps,
     controlAttributionPropsDefaults,
     setupControlAttribution
-} from '../functions/controlAttribution'
-import { RegisterControlInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder } from '../utils'
+} from '@/functions/controlAttribution'
+import { RegisterControlInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder } from '@/utils'
 
 /**
  * > The attribution control allows you to display attribution data in a small text bos on a map.

--- a/src/components/LControlAttribution.vue
+++ b/src/components/LControlAttribution.vue
@@ -9,7 +9,7 @@ import {
     setupControlAttribution
 } from '../functions/controlAttribution'
 import { RegisterControlInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder } from '../utils.js'
+import { assertInject, propsBinder } from '../utils'
 
 /**
  * > The attribution control allows you to display attribution data in a small text bos on a map.

--- a/src/components/LControlLayers.vue
+++ b/src/components/LControlLayers.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { markRaw, nextTick, onMounted, ref } from 'vue'
 import { Control } from 'leaflet'
-import { RegisterLayerControlInjection } from '../types/injectionKeys.ts'
+import { RegisterLayerControlInjection } from '../types/injectionKeys'
 import {
     type ControlLayersEmits,
     type ControlLayersProps,
     controlLayersPropsDefaults,
     setupControlLayers
-} from '../functions/controlLayers.ts'
-import { assertInject, propsBinder } from '../utils.ts'
+} from '../functions/controlLayers'
+import { assertInject, propsBinder } from '../utils'
 /**
  * > The layers control gives users the ability to switch between different base layers and switch overlays on/off.
  * @demo ControlLayersDemo {18}

--- a/src/components/LControlLayers.vue
+++ b/src/components/LControlLayers.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { markRaw, nextTick, onMounted, ref } from 'vue'
 import { Control } from 'leaflet'
-import { RegisterLayerControlInjection } from '../types/injectionKeys'
+import { RegisterLayerControlInjection } from '@/types/injectionKeys'
 import {
     type ControlLayersEmits,
     type ControlLayersProps,
     controlLayersPropsDefaults,
     setupControlLayers
-} from '../functions/controlLayers'
-import { assertInject, propsBinder } from '../utils'
+} from '@/functions/controlLayers'
+import { assertInject, propsBinder } from '@/utils'
 /**
  * > The layers control gives users the ability to switch between different base layers and switch overlays on/off.
  * @demo ControlLayersDemo {18}

--- a/src/components/LControlScale.vue
+++ b/src/components/LControlScale.vue
@@ -3,13 +3,13 @@ import { Control } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref } from 'vue'
 
 import { RegisterControlInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder } from '../utils.js'
+import { assertInject, propsBinder } from '../utils'
 import {
     type ControlScaleEmits,
     type ControlScaleProps,
     controlScalePropsDefaults,
     setupControlScale
-} from '../functions/controlScale.ts'
+} from '../functions/controlScale'
 
 /**
  * > A simple scale control that shows the scale of the current center of screen in metric (m/km) and imperial (mi/ft) systems.

--- a/src/components/LControlScale.vue
+++ b/src/components/LControlScale.vue
@@ -2,14 +2,14 @@
 import { Control } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref } from 'vue'
 
-import { RegisterControlInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder } from '../utils'
+import { RegisterControlInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder } from '@/utils'
 import {
     type ControlScaleEmits,
     type ControlScaleProps,
     controlScalePropsDefaults,
     setupControlScale
-} from '../functions/controlScale'
+} from '@/functions/controlScale'
 
 /**
  * > A simple scale control that shows the scale of the current center of screen in metric (m/km) and imperial (mi/ft) systems.

--- a/src/components/LControlZoom.vue
+++ b/src/components/LControlZoom.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { markRaw, nextTick, onMounted, ref } from 'vue'
 
-import { RegisterControlInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder } from '../utils'
+import { RegisterControlInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder } from '@/utils'
 import {
     type ControlZoomEmits,
     type ControlZoomProps,
     controlZoomPropsDefaults,
     setupControlZoom
-} from '../functions/controlZoom'
+} from '@/functions/controlZoom'
 import { Control } from 'leaflet'
 
 /**

--- a/src/components/LControlZoom.vue
+++ b/src/components/LControlZoom.vue
@@ -2,13 +2,13 @@
 import { markRaw, nextTick, onMounted, ref } from 'vue'
 
 import { RegisterControlInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder } from '../utils.js'
+import { assertInject, propsBinder } from '../utils'
 import {
     type ControlZoomEmits,
     type ControlZoomProps,
     controlZoomPropsDefaults,
     setupControlZoom
-} from '../functions/controlZoom.ts'
+} from '../functions/controlZoom'
 import { Control } from 'leaflet'
 
 /**

--- a/src/components/LFeatureGroup.vue
+++ b/src/components/LFeatureGroup.vue
@@ -3,13 +3,13 @@ import { FeatureGroup } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 
 import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 import {
     type FeatureGroupEmits,
     type FeatureGroupProps,
     featureGroupPropsDefaults,
     setupFeatureGroup
-} from '../functions/featureGroup.ts'
+} from '../functions/featureGroup'
 
 /**
  * > Extended [LLayerGroup](/components/l-layer-group.html) that makes it easier to do the same thing to all its member layers.

--- a/src/components/LFeatureGroup.vue
+++ b/src/components/LFeatureGroup.vue
@@ -2,14 +2,14 @@
 import { FeatureGroup } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 
-import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+import { AddLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 import {
     type FeatureGroupEmits,
     type FeatureGroupProps,
     featureGroupPropsDefaults,
     setupFeatureGroup
-} from '../functions/featureGroup'
+} from '@/functions/featureGroup'
 
 /**
  * > Extended [LLayerGroup](/components/l-layer-group.html) that makes it easier to do the same thing to all its member layers.

--- a/src/components/LGeoJson.vue
+++ b/src/components/LGeoJson.vue
@@ -2,13 +2,13 @@
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 
 import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 import {
     type GeoJSONEmits,
     type GeoJSONProps,
     geoJSONPropsDefaults,
     setupGeoJSON
-} from '../functions/geoJSON.ts'
+} from '../functions/geoJSON'
 import { GeoJSON } from 'leaflet'
 
 /**

--- a/src/components/LGeoJson.vue
+++ b/src/components/LGeoJson.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 
-import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+import { AddLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 import {
     type GeoJSONEmits,
     type GeoJSONProps,
     geoJSONPropsDefaults,
     setupGeoJSON
-} from '../functions/geoJSON'
+} from '@/functions/geoJSON'
 import { GeoJSON } from 'leaflet'
 
 /**

--- a/src/components/LGridLayer.vue
+++ b/src/components/LGridLayer.vue
@@ -5,10 +5,10 @@ import {
     type GridLayerProps,
     gridLayerPropsDefaults,
     setupGridLayer
-} from '../functions/gridLayer.ts'
+} from '../functions/gridLayer'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
-import { AddLayerInjection } from '../types/injectionKeys.ts'
-import { assertInject, propsBinder, remapEvents } from '../utils.ts'
+import { AddLayerInjection } from '../types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 import { GridLayer } from 'leaflet'
 
 /**

--- a/src/components/LGridLayer.vue
+++ b/src/components/LGridLayer.vue
@@ -5,10 +5,10 @@ import {
     type GridLayerProps,
     gridLayerPropsDefaults,
     setupGridLayer
-} from '../functions/gridLayer'
+} from '@/functions/gridLayer'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
-import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+import { AddLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 import { GridLayer } from 'leaflet'
 
 /**

--- a/src/components/LIcon.vue
+++ b/src/components/LIcon.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
-import { type IconProps, iconPropsDefaults } from '../functions/icon'
+import { type IconProps, iconPropsDefaults } from '@/functions/icon'
 import { nextTick, onMounted, ref, useAttrs } from 'vue'
-import { assertInject, propsBinder, propsToLeafletOptions, remapEvents } from '../utils'
+import { assertInject, propsBinder, propsToLeafletOptions, remapEvents } from '@/utils'
 import {
     CanSetParentHtmlInjection,
     SetIconInjection,
     SetParentHtmlInjection
-} from '../types/injectionKeys'
+} from '@/types/injectionKeys'
 import { DivIcon, type DivIconOptions, DomEvent, Icon } from 'leaflet'
-import { setupComponent } from '../functions/component'
+import { setupComponent } from '@/functions/component'
 
 /**
  * > Easy and reactive way to configure the icon of a marker

--- a/src/components/LIcon.vue
+++ b/src/components/LIcon.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
-import { type IconProps, iconPropsDefaults } from '../functions/icon.ts'
+import { type IconProps, iconPropsDefaults } from '../functions/icon'
 import { nextTick, onMounted, ref, useAttrs } from 'vue'
-import { assertInject, propsBinder, propsToLeafletOptions, remapEvents } from '../utils.ts'
+import { assertInject, propsBinder, propsToLeafletOptions, remapEvents } from '../utils'
 import {
     CanSetParentHtmlInjection,
     SetIconInjection,
     SetParentHtmlInjection
-} from '../types/injectionKeys.ts'
+} from '../types/injectionKeys'
 import { DivIcon, type DivIconOptions, DomEvent, Icon } from 'leaflet'
-import { setupComponent } from '../functions/component.ts'
+import { setupComponent } from '../functions/component'
 
 /**
  * > Easy and reactive way to configure the icon of a marker

--- a/src/components/LImageOverlay.vue
+++ b/src/components/LImageOverlay.vue
@@ -7,9 +7,9 @@ import {
     type ImageOverlayProps,
     imageOverlayPropsDefaults,
     setupImageOverlay
-} from '../functions/imageOverlay'
-import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+} from '@/functions/imageOverlay'
+import { AddLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 
 /**
  * > Used to load and display a single image over specific bounds of the map.

--- a/src/components/LImageOverlay.vue
+++ b/src/components/LImageOverlay.vue
@@ -9,7 +9,7 @@ import {
     setupImageOverlay
 } from '../functions/imageOverlay'
 import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 
 /**
  * > Used to load and display a single image over specific bounds of the map.

--- a/src/components/LLayerGroup.vue
+++ b/src/components/LLayerGroup.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { LayerGroup } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
-import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+import { AddLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 import {
     type LayerGroupEmits,
     type LayerGroupProps,
     layerGroupPropsDefaults,
     setupLayerGroup
-} from '../functions/layerGroup'
+} from '@/functions/layerGroup'
 
 /**
  * > Use to group several layers and handle them as one. If you add it to the map, any layers added or removed from the group will be added/removed on the map as well.

--- a/src/components/LLayerGroup.vue
+++ b/src/components/LLayerGroup.vue
@@ -2,13 +2,13 @@
 import { LayerGroup } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 import {
     type LayerGroupEmits,
     type LayerGroupProps,
     layerGroupPropsDefaults,
     setupLayerGroup
-} from '../functions/layerGroup.ts'
+} from '../functions/layerGroup'
 
 /**
  * > Use to group several layers and handle them as one. If you add it to the map, any layers added or removed from the group will be added/removed on the map as well.

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -35,16 +35,16 @@ import {
     remapEvents,
     resetWebpackIcon,
     updateLeafletWrapper
-} from '../utils.ts'
+} from '../utils'
 import type { IControlDefinition, ILayerDefinition } from '../types/interfaces'
 import {
     AddLayerInjection,
     RegisterControlInjection,
     RegisterLayerControlInjection,
     RemoveLayerInjection
-} from '../types/injectionKeys.ts'
-import type { IMapBlueprint } from '../types/interfaces/IMapBlueprint.ts'
-import { type MapProps, mapPropsDefaults, setupMap } from '../functions/map.ts'
+} from '../types/injectionKeys'
+import type { IMapBlueprint } from '../types/interfaces/IMapBlueprint'
+import { type MapProps, mapPropsDefaults, setupMap } from '../functions/map'
 
 /**
  * > Base component, contains and wraps all the other components.

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -35,16 +35,16 @@ import {
     remapEvents,
     resetWebpackIcon,
     updateLeafletWrapper
-} from '../utils'
-import type { IControlDefinition, ILayerDefinition } from '../types/interfaces'
+} from '@/utils'
+import type { IControlDefinition, ILayerDefinition } from '@/types/interfaces'
 import {
     AddLayerInjection,
     RegisterControlInjection,
     RegisterLayerControlInjection,
     RemoveLayerInjection
-} from '../types/injectionKeys'
-import type { IMapBlueprint } from '../types/interfaces/IMapBlueprint'
-import { type MapProps, mapPropsDefaults, setupMap } from '../functions/map'
+} from '@/types/injectionKeys'
+import type { IMapBlueprint } from '@/types/interfaces/IMapBlueprint'
+import { type MapProps, mapPropsDefaults, setupMap } from '@/functions/map'
 
 /**
  * > Base component, contains and wraps all the other components.

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -16,13 +16,13 @@ import {
     isFunction,
     propsBinder,
     remapEvents,
-} from '../utils'
+} from '@/utils'
 import {
     AddLayerInjection,
     CanSetParentHtmlInjection,
     SetIconInjection,
     SetParentHtmlInjection,
-} from '../types/injectionKeys'
+} from '@/types/injectionKeys'
 import { DivIcon, Icon, type LeafletEventHandlerFnMap, Marker } from 'leaflet'
 import { debounce } from 'ts-debounce'
 import {
@@ -31,7 +31,7 @@ import {
     markerPropsDefaults,
     setupMarker,
     shouldBlankIcon,
-} from '../functions/marker'
+} from '@/functions/marker'
 
 /**
  * > Used to display clickable/draggable markers on the map.

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -16,13 +16,13 @@ import {
     isFunction,
     propsBinder,
     remapEvents,
-} from '../utils.ts'
+} from '../utils'
 import {
     AddLayerInjection,
     CanSetParentHtmlInjection,
     SetIconInjection,
     SetParentHtmlInjection,
-} from '../types/injectionKeys.ts'
+} from '../types/injectionKeys'
 import { DivIcon, Icon, type LeafletEventHandlerFnMap, Marker } from 'leaflet'
 import { debounce } from 'ts-debounce'
 import {
@@ -31,7 +31,7 @@ import {
     markerPropsDefaults,
     setupMarker,
     shouldBlankIcon,
-} from '../functions/marker.ts'
+} from '../functions/marker'
 
 /**
  * > Used to display clickable/draggable markers on the map.

--- a/src/components/LPolygon.vue
+++ b/src/components/LPolygon.vue
@@ -5,9 +5,9 @@ import {
     type PolygonProps,
     polygonPropsDefaults,
     setupPolygon
-} from '../functions/polygon'
-import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+} from '@/functions/polygon'
+import { AddLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 import { Polygon } from 'leaflet'
 
 /**

--- a/src/components/LPolygon.vue
+++ b/src/components/LPolygon.vue
@@ -7,7 +7,7 @@ import {
     setupPolygon
 } from '../functions/polygon'
 import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 import { Polygon } from 'leaflet'
 
 /**

--- a/src/components/LPolyline.vue
+++ b/src/components/LPolyline.vue
@@ -5,9 +5,9 @@ import {
     type PolylineProps,
     polylinePropsDefaults,
     setupPolyline
-} from '../functions/polyline'
-import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+} from '@/functions/polyline'
+import { AddLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 import { Polyline } from 'leaflet'
 
 /**

--- a/src/components/LPolyline.vue
+++ b/src/components/LPolyline.vue
@@ -7,7 +7,7 @@ import {
     setupPolyline
 } from '../functions/polyline'
 import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 import { Polyline } from 'leaflet'
 
 /**

--- a/src/components/LPopup.vue
+++ b/src/components/LPopup.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { markRaw, nextTick, onBeforeUnmount, onMounted, ref, useAttrs } from 'vue'
-import { BindPopupInjection, UnbindPopupInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+import { BindPopupInjection, UnbindPopupInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 import { Popup, Tooltip } from 'leaflet'
-import { type PopupProps, popupPropsDefaults, setupPopup } from '../functions/popup'
+import { type PopupProps, popupPropsDefaults, setupPopup } from '@/functions/popup'
 
 /**
  * > Display a popup on the map

--- a/src/components/LPopup.vue
+++ b/src/components/LPopup.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { markRaw, nextTick, onBeforeUnmount, onMounted, ref, useAttrs } from 'vue'
 import { BindPopupInjection, UnbindPopupInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 import { Popup, Tooltip } from 'leaflet'
-import { type PopupProps, popupPropsDefaults, setupPopup } from '../functions/popup.ts'
+import { type PopupProps, popupPropsDefaults, setupPopup } from '../functions/popup'
 
 /**
  * > Display a popup on the map

--- a/src/components/LRectangle.vue
+++ b/src/components/LRectangle.vue
@@ -6,9 +6,9 @@ import {
     type RectangleProps,
     rectanglePropsDefaults,
     setupRectangle
-} from '../functions/rectangle'
-import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+} from '@/functions/rectangle'
+import { AddLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 import { LatLngBounds, Rectangle } from 'leaflet'
 
 /**

--- a/src/components/LRectangle.vue
+++ b/src/components/LRectangle.vue
@@ -8,7 +8,7 @@ import {
     setupRectangle
 } from '../functions/rectangle'
 import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 import { LatLngBounds, Rectangle } from 'leaflet'
 
 /**

--- a/src/components/LSVGOverlay.vue
+++ b/src/components/LSVGOverlay.vue
@@ -2,13 +2,13 @@
 import { SVGOverlay } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 import {
     setupSVGOverlay,
     type SVGOverlayEmits,
     type SVGOverlayProps,
     svgOverlayPropsDefaults
-} from '../functions/svgOverlay.ts'
+} from '../functions/svgOverlay'
 
 /**
  * > Used to load and display a single svg over specific bounds of the map.

--- a/src/components/LSVGOverlay.vue
+++ b/src/components/LSVGOverlay.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { SVGOverlay } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
-import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+import { AddLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 import {
     setupSVGOverlay,
     type SVGOverlayEmits,
     type SVGOverlayProps,
     svgOverlayPropsDefaults
-} from '../functions/svgOverlay'
+} from '@/functions/svgOverlay'
 
 /**
  * > Used to load and display a single svg over specific bounds of the map.

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 import { TileLayer } from 'leaflet'
-import { assertInject, propsBinder, remapEvents } from '../utils'
-import { AddLayerInjection } from '../types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
+import { AddLayerInjection } from '@/types/injectionKeys'
 import {
     setupTileLayer,
     type TileLayerEmits,
     type TileLayerProps,
     tileLayerPropsDefaults
-} from '../functions/tileLayer'
+} from '@/functions/tileLayer'
 
 /**
  * > Load tiles from a map server and display them accordingly to map zoom, center and size.

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 import { TileLayer } from 'leaflet'
-import { assertInject, propsBinder, remapEvents } from '../utils.ts'
-import { AddLayerInjection } from '../types/injectionKeys.ts'
+import { assertInject, propsBinder, remapEvents } from '../utils'
+import { AddLayerInjection } from '../types/injectionKeys'
 import {
     setupTileLayer,
     type TileLayerEmits,
     type TileLayerProps,
     tileLayerPropsDefaults
-} from '../functions/tileLayer.ts'
+} from '../functions/tileLayer'
 
 /**
  * > Load tiles from a map server and display them accordingly to map zoom, center and size.

--- a/src/components/LTooltip.vue
+++ b/src/components/LTooltip.vue
@@ -3,8 +3,8 @@ import { Tooltip } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 import { setupTooltip } from '../functions/tooltip'
 import { BindTooltipInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
-import { type TooltipProps, tooltipPropsDefaults } from '../functions/tooltip.ts'
+import { assertInject, propsBinder, remapEvents } from '../utils'
+import { type TooltipProps, tooltipPropsDefaults } from '../functions/tooltip'
 
 /**
  * > Display a tooltip on the map

--- a/src/components/LTooltip.vue
+++ b/src/components/LTooltip.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { Tooltip } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
-import { setupTooltip } from '../functions/tooltip'
-import { BindTooltipInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
-import { type TooltipProps, tooltipPropsDefaults } from '../functions/tooltip'
+import { setupTooltip } from '@/functions/tooltip'
+import { BindTooltipInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
+import { type TooltipProps, tooltipPropsDefaults } from '@/functions/tooltip'
 
 /**
  * > Display a tooltip on the map

--- a/src/components/LVideoOverlay.vue
+++ b/src/components/LVideoOverlay.vue
@@ -3,13 +3,13 @@ import { VideoOverlay } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 
 import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 import {
     setupVideoOverlay,
     type VideoOverlayEmits,
     type VideoOverlayProps,
     videoOverlayPropsDefaults
-} from '../functions/videoOverlay.ts'
+} from '../functions/videoOverlay'
 
 /**
  * > Used to load and display a video over specific bounds of the map.

--- a/src/components/LVideoOverlay.vue
+++ b/src/components/LVideoOverlay.vue
@@ -2,14 +2,14 @@
 import { VideoOverlay } from 'leaflet'
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
 
-import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+import { AddLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 import {
     setupVideoOverlay,
     type VideoOverlayEmits,
     type VideoOverlayProps,
     videoOverlayPropsDefaults
-} from '../functions/videoOverlay'
+} from '@/functions/videoOverlay'
 
 /**
  * > Used to load and display a video over specific bounds of the map.

--- a/src/components/LWmsTileLayer.vue
+++ b/src/components/LWmsTileLayer.vue
@@ -8,7 +8,7 @@ import {
     wmsTileLayerPropsDefaults
 } from '../functions/wmsTileLayer'
 import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils.js'
+import { assertInject, propsBinder, remapEvents } from '../utils'
 import { TileLayer } from 'leaflet'
 
 /**

--- a/src/components/LWmsTileLayer.vue
+++ b/src/components/LWmsTileLayer.vue
@@ -6,9 +6,9 @@ import {
     type WmsTileLayerEmits,
     type WmsTileLayerProps,
     wmsTileLayerPropsDefaults
-} from '../functions/wmsTileLayer'
-import { AddLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsBinder, remapEvents } from '../utils'
+} from '@/functions/wmsTileLayer'
+import { AddLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsBinder, remapEvents } from '@/utils'
 import { TileLayer } from 'leaflet'
 
 /**

--- a/src/functions/circle.ts
+++ b/src/functions/circle.ts
@@ -1,6 +1,6 @@
 import { Circle, type CircleOptions } from 'leaflet'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import {
     type CircleMarkerEmits,

--- a/src/functions/circleMarker.ts
+++ b/src/functions/circleMarker.ts
@@ -1,4 +1,4 @@
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import { type PathEmits, type PathProps, pathPropsDefaults, setupPath as pathSetup } from './path'
 import { CircleMarker, type CircleMarkerOptions, type LatLngExpression } from 'leaflet'

--- a/src/functions/control.ts
+++ b/src/functions/control.ts
@@ -3,7 +3,7 @@ import { onUnmounted, type Ref } from 'vue'
 
 import { propsToLeafletOptions } from '@/utils'
 
-import { type ComponentProps, componentPropsDefaults, setupComponent } from './component'
+import { type ComponentProps, componentPropsDefaults, setupComponent } from '@/functions/component'
 
 export interface ControlAbstractProps<T extends ControlOptions = ControlOptions>
     extends ComponentProps<T> {

--- a/src/functions/control.ts
+++ b/src/functions/control.ts
@@ -1,7 +1,7 @@
 import type { Control, ControlOptions, ControlPosition } from 'leaflet'
 import { onUnmounted, type Ref } from 'vue'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import { type ComponentProps, componentPropsDefaults, setupComponent } from './component'
 

--- a/src/functions/controlAttribution.ts
+++ b/src/functions/controlAttribution.ts
@@ -1,6 +1,6 @@
 import { Control } from 'leaflet'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import { type ControlEmits, type ControlAbstractProps, controlAbstractPropsDefaults, setupControl } from './control'
 import type { Ref } from 'vue'

--- a/src/functions/controlAttribution.ts
+++ b/src/functions/controlAttribution.ts
@@ -2,7 +2,7 @@ import { Control } from 'leaflet'
 
 import { propsToLeafletOptions } from '../utils'
 
-import { type ControlEmits, type ControlAbstractProps, controlAbstractPropsDefaults, setupControl } from './control.ts'
+import { type ControlEmits, type ControlAbstractProps, controlAbstractPropsDefaults, setupControl } from './control'
 import type { Ref } from 'vue'
 
 export interface ControlAttributionProps extends ControlAbstractProps<Control.AttributionOptions> {

--- a/src/functions/controlLayers.ts
+++ b/src/functions/controlLayers.ts
@@ -1,10 +1,10 @@
 import type { Control, Layer } from 'leaflet'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import { type ControlEmits, type ControlAbstractProps, controlAbstractPropsDefaults, setupControl } from './control'
 import type { Ref } from 'vue'
-import type { ILayerDefinition } from '../types/interfaces'
+import type { ILayerDefinition } from '@/types/interfaces'
 
 export interface ControlLayersProps extends ControlAbstractProps<Control.LayersOptions> {
     /**

--- a/src/functions/controlScale.ts
+++ b/src/functions/controlScale.ts
@@ -1,6 +1,6 @@
 import { Control } from 'leaflet'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import { type ControlEmits, type ControlAbstractProps, controlAbstractPropsDefaults, setupControl } from './control'
 import type { Ref } from 'vue'

--- a/src/functions/controlZoom.ts
+++ b/src/functions/controlZoom.ts
@@ -1,6 +1,6 @@
 import { Control } from 'leaflet'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import { type ControlEmits, type ControlAbstractProps, controlAbstractPropsDefaults, setupControl } from './control'
 import type { Ref } from 'vue'

--- a/src/functions/featureGroup.ts
+++ b/src/functions/featureGroup.ts
@@ -1,6 +1,6 @@
 import { FeatureGroup, type InteractiveLayerOptions } from 'leaflet'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import {
     type LayerGroupEmits,

--- a/src/functions/geoJSON.ts
+++ b/src/functions/geoJSON.ts
@@ -2,7 +2,7 @@ import type { GeoJsonObject } from 'geojson'
 import type { GeoJSON, GeoJSONOptions, PathOptions, StyleFunction } from 'leaflet'
 import type { Ref } from 'vue'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import {
     type LayerGroupEmits,

--- a/src/functions/gridLayer.ts
+++ b/src/functions/gridLayer.ts
@@ -8,8 +8,8 @@ import {
     type PointExpression,
     type TileEvent,
 } from 'leaflet'
-import { type LayerEmits, type LayerProps, layerPropsDefaults, setupLayer } from './layer.ts'
-import { propsToLeafletOptions } from '../utils.ts'
+import { type LayerEmits, type LayerProps, layerPropsDefaults, setupLayer } from './layer'
+import { propsToLeafletOptions } from '../utils'
 
 export interface GridLayerAbstractProps<T extends GridLayerOptions = GridLayerOptions>
     extends LayerProps<T> {

--- a/src/functions/gridLayer.ts
+++ b/src/functions/gridLayer.ts
@@ -9,7 +9,7 @@ import {
     type TileEvent,
 } from 'leaflet'
 import { type LayerEmits, type LayerProps, layerPropsDefaults, setupLayer } from './layer'
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 export interface GridLayerAbstractProps<T extends GridLayerOptions = GridLayerOptions>
     extends LayerProps<T> {

--- a/src/functions/icon.ts
+++ b/src/functions/icon.ts
@@ -1,5 +1,5 @@
 import type { DivIconOptions, PointExpression } from 'leaflet'
-import { type ComponentProps, componentPropsDefaults } from './component.ts'
+import { type ComponentProps, componentPropsDefaults } from './component'
 
 export interface IconProps extends ComponentProps<DivIconOptions> {
     /**

--- a/src/functions/icon.ts
+++ b/src/functions/icon.ts
@@ -1,5 +1,5 @@
 import type { DivIconOptions, PointExpression } from 'leaflet'
-import { type ComponentProps, componentPropsDefaults } from './component'
+import { type ComponentProps, componentPropsDefaults } from '@/functions/component'
 
 export interface IconProps extends ComponentProps<DivIconOptions> {
     /**

--- a/src/functions/imageOverlay.ts
+++ b/src/functions/imageOverlay.ts
@@ -6,7 +6,7 @@ import type {
 } from 'leaflet'
 import type { Ref } from 'vue'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import { type LayerEmits, type LayerProps, layerPropsDefaults, setupLayer } from './layer'
 

--- a/src/functions/interactiveLayer.ts
+++ b/src/functions/interactiveLayer.ts
@@ -1,6 +1,6 @@
 import { type InteractiveLayerOptions, type Layer } from 'leaflet'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import { type LayerEmits, type LayerProps, layerPropsDefaults, setupLayer } from './layer'
 import type { Ref } from 'vue'

--- a/src/functions/layer.ts
+++ b/src/functions/layer.ts
@@ -11,7 +11,7 @@ import {
 import { assertInject, isFunction, propsToLeafletOptions } from '@/utils'
 
 import type { LayerType } from '@/types/enums/LayerType'
-import { type ComponentProps, componentPropsDefaults, setupComponent } from './component'
+import { type ComponentProps, componentPropsDefaults, setupComponent } from '@/functions/component'
 import type { Layer, LayerOptions, Popup, Tooltip } from 'leaflet'
 
 export interface LayerProps<T extends LayerOptions = LayerOptions> extends ComponentProps<T> {

--- a/src/functions/layer.ts
+++ b/src/functions/layer.ts
@@ -7,10 +7,10 @@ import {
     RemoveLayerInjection,
     UnbindPopupInjection,
     UnbindTooltipInjection,
-} from '../types/injectionKeys'
-import { assertInject, isFunction, propsToLeafletOptions } from '../utils'
+} from '@/types/injectionKeys'
+import { assertInject, isFunction, propsToLeafletOptions } from '@/utils'
 
-import type { LayerType } from '../types/enums/LayerType'
+import type { LayerType } from '@/types/enums/LayerType'
 import { type ComponentProps, componentPropsDefaults, setupComponent } from './component'
 import type { Layer, LayerOptions, Popup, Tooltip } from 'leaflet'
 

--- a/src/functions/layerGroup.ts
+++ b/src/functions/layerGroup.ts
@@ -1,11 +1,11 @@
 import { type InteractiveLayerOptions, LayerGroup, type LayerOptions } from 'leaflet'
 import { provide, type Ref } from 'vue'
 
-import { AddLayerInjection, RemoveLayerInjection } from '../types/injectionKeys'
-import { propsToLeafletOptions } from '../utils'
+import { AddLayerInjection, RemoveLayerInjection } from '@/types/injectionKeys'
+import { propsToLeafletOptions } from '@/utils'
 
 import { type LayerEmits, type LayerProps, layerPropsDefaults, setupLayer } from './layer'
-import type { ILayerDefinition } from '../types/interfaces'
+import type { ILayerDefinition } from '@/types/interfaces'
 
 /* eslint-disable @typescript-eslint/no-empty-object-type */
 export interface LayerGroupProps<T extends LayerOptions = LayerOptions> extends LayerProps<T> {

--- a/src/functions/map.ts
+++ b/src/functions/map.ts
@@ -1,5 +1,5 @@
 import { type CRS, LatLngBounds, type MapOptions, type PointExpression } from 'leaflet'
-import { type ComponentProps, componentPropsDefaults, setupComponent } from './component'
+import { type ComponentProps, componentPropsDefaults, setupComponent } from '@/functions/component'
 
 export interface MapProps extends ComponentProps<MapOptions> {
     /**

--- a/src/functions/map.ts
+++ b/src/functions/map.ts
@@ -1,5 +1,5 @@
 import { type CRS, LatLngBounds, type MapOptions, type PointExpression } from 'leaflet'
-import { type ComponentProps, componentPropsDefaults, setupComponent } from './component.ts'
+import { type ComponentProps, componentPropsDefaults, setupComponent } from './component'
 
 export interface MapProps extends ComponentProps<MapOptions> {
     /**

--- a/src/functions/marker.ts
+++ b/src/functions/marker.ts
@@ -2,7 +2,7 @@ import type { Icon, LatLngExpression, LeafletEvent, Marker, MarkerOptions } from
 import type { Ref, Slots, VNode } from 'vue'
 
 import { type LayerEmits, type LayerProps, layerPropsDefaults, setupLayer } from './layer'
-import { propsToLeafletOptions } from '../utils.ts'
+import { propsToLeafletOptions } from '../utils'
 
 const unrenderedContentTypes = ['Symbol(Comment)', 'Symbol(Text)']
 const unrenderedComponentNames = ['LTooltip', 'LPopup']

--- a/src/functions/marker.ts
+++ b/src/functions/marker.ts
@@ -2,7 +2,7 @@ import type { Icon, LatLngExpression, LeafletEvent, Marker, MarkerOptions } from
 import type { Ref, Slots, VNode } from 'vue'
 
 import { type LayerEmits, type LayerProps, layerPropsDefaults, setupLayer } from './layer'
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 const unrenderedContentTypes = ['Symbol(Comment)', 'Symbol(Text)']
 const unrenderedComponentNames = ['LTooltip', 'LPopup']

--- a/src/functions/path.ts
+++ b/src/functions/path.ts
@@ -1,8 +1,8 @@
 import type { FillRule, LineCapShape, LineJoinShape, Path, PathOptions } from 'leaflet'
 import { onBeforeUnmount, type Ref } from 'vue'
 
-import { RemoveLayerInjection } from '../types/injectionKeys'
-import { assertInject, propsToLeafletOptions } from '../utils'
+import { RemoveLayerInjection } from '@/types/injectionKeys'
+import { assertInject, propsToLeafletOptions } from '@/utils'
 
 import {
     type InteractiveLayerEmits,

--- a/src/functions/polygon.ts
+++ b/src/functions/polygon.ts
@@ -1,6 +1,6 @@
 import { Polygon, type PolylineOptions } from 'leaflet'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import {
     type PolylineEmits,

--- a/src/functions/polyline.ts
+++ b/src/functions/polyline.ts
@@ -1,6 +1,6 @@
 import { type LatLngExpression, Polyline, type PolylineOptions } from 'leaflet'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import { type PathEmits, type PathProps, pathPropsDefaults, setupPath } from './path'
 import type { Ref } from 'vue'

--- a/src/functions/popper.ts
+++ b/src/functions/popper.ts
@@ -1,6 +1,6 @@
 import { type Ref } from 'vue'
 
-import { type ComponentProps, componentPropsDefaults, setupComponent } from './component'
+import { type ComponentProps, componentPropsDefaults, setupComponent } from '@/functions/component'
 import { type DivOverlay } from 'leaflet'
 
 export interface PopperProps<T extends object> extends ComponentProps<T> {

--- a/src/functions/rectangle.ts
+++ b/src/functions/rectangle.ts
@@ -1,6 +1,6 @@
 import { type LatLngBoundsExpression, type LatLngExpression, type PolylineOptions, Rectangle } from 'leaflet'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import { type PolygonEmits, type PolygonProps, polygonPropsDefaults, setupPolygon } from './polygon'
 import type { Ref } from 'vue'

--- a/src/functions/svgOverlay.ts
+++ b/src/functions/svgOverlay.ts
@@ -2,7 +2,7 @@ import type { ImageOverlayOptions } from 'leaflet'
 import { SVGOverlay } from 'leaflet'
 import type { Ref } from 'vue'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 import type { ImageOverlayAbstractProps, ImageOverlayEmits } from './imageOverlay'
 import { imageOverlayPropsDefaults, setupImageOverlay } from './imageOverlay'
 

--- a/src/functions/svgOverlay.ts
+++ b/src/functions/svgOverlay.ts
@@ -3,8 +3,8 @@ import { SVGOverlay } from 'leaflet'
 import type { Ref } from 'vue'
 
 import { propsToLeafletOptions } from '../utils'
-import type { ImageOverlayAbstractProps, ImageOverlayEmits } from './imageOverlay.ts'
-import { imageOverlayPropsDefaults, setupImageOverlay } from './imageOverlay.ts'
+import type { ImageOverlayAbstractProps, ImageOverlayEmits } from './imageOverlay'
+import { imageOverlayPropsDefaults, setupImageOverlay } from './imageOverlay'
 
 export interface SVGOverlayProps extends ImageOverlayAbstractProps {
     /**

--- a/src/functions/tileLayer.ts
+++ b/src/functions/tileLayer.ts
@@ -6,7 +6,7 @@ import {
 } from './gridLayer'
 import type { Ref } from 'vue'
 import { type TileLayer, type TileLayerOptions } from 'leaflet'
-import { propsToLeafletOptions } from '../utils.ts'
+import { propsToLeafletOptions } from '../utils'
 
 export interface TileLayerProps<T extends TileLayerOptions = TileLayerOptions> extends GridLayerAbstractProps<T> {
     /**

--- a/src/functions/tileLayer.ts
+++ b/src/functions/tileLayer.ts
@@ -6,7 +6,7 @@ import {
 } from './gridLayer'
 import type { Ref } from 'vue'
 import { type TileLayer, type TileLayerOptions } from 'leaflet'
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 export interface TileLayerProps<T extends TileLayerOptions = TileLayerOptions> extends GridLayerAbstractProps<T> {
     /**

--- a/src/functions/tooltip.ts
+++ b/src/functions/tooltip.ts
@@ -1,7 +1,7 @@
 import { onBeforeUnmount, type Ref } from 'vue'
 
-import { UnbindTooltipInjection } from '../types/injectionKeys'
-import { assertInject } from '../utils'
+import { UnbindTooltipInjection } from '@/types/injectionKeys'
+import { assertInject } from '@/utils'
 
 import { type PopperProps, popperPropsDefaults, setupPopper } from './popper'
 import type { Tooltip, TooltipOptions } from 'leaflet'

--- a/src/functions/videoOverlay.ts
+++ b/src/functions/videoOverlay.ts
@@ -2,8 +2,8 @@ import type { VideoOverlay, VideoOverlayOptions } from 'leaflet'
 import type { Ref } from 'vue'
 
 import { propsToLeafletOptions } from '../utils'
-import type { ImageOverlayAbstractProps, ImageOverlayEmits } from './imageOverlay.ts'
-import { imageOverlayPropsDefaults, setupImageOverlay } from './imageOverlay.ts'
+import type { ImageOverlayAbstractProps, ImageOverlayEmits } from './imageOverlay'
+import { imageOverlayPropsDefaults, setupImageOverlay } from './imageOverlay'
 
 export interface VideoOverlayProps extends ImageOverlayAbstractProps<VideoOverlayOptions> {
     /**

--- a/src/functions/videoOverlay.ts
+++ b/src/functions/videoOverlay.ts
@@ -1,7 +1,7 @@
 import type { VideoOverlay, VideoOverlayOptions } from 'leaflet'
 import type { Ref } from 'vue'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 import type { ImageOverlayAbstractProps, ImageOverlayEmits } from './imageOverlay'
 import { imageOverlayPropsDefaults, setupImageOverlay } from './imageOverlay'
 

--- a/src/functions/wmsTileLayer.ts
+++ b/src/functions/wmsTileLayer.ts
@@ -1,6 +1,6 @@
 import type { CRS, TileLayer, WMSOptions } from 'leaflet'
 
-import { propsToLeafletOptions } from '../utils'
+import { propsToLeafletOptions } from '@/utils'
 
 import {
     setupTileLayer,

--- a/src/playground/views/CircleDemo.vue
+++ b/src/playground/views/CircleDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LCircle, LMap, LTileLayer } from '../../components'
+import { LCircle, LMap, LTileLayer } from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/playground/views/CircleMarkerDemo.vue
+++ b/src/playground/views/CircleMarkerDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LCircleMarker, LMap, LTileLayer } from '../../components'
+import { LCircleMarker, LMap, LTileLayer } from '@/maxel01/vue-leaflet'
 import { ref } from 'vue'
 
 const zoom = ref<number>(16)

--- a/src/playground/views/ControlAttributionDemo.vue
+++ b/src/playground/views/ControlAttributionDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LControlAttribution, LMap, LTileLayer } from '../../components'
+import { LControlAttribution, LMap, LTileLayer } from '@/maxel01/vue-leaflet'
 import { ref } from 'vue'
 
 const customAttributionPrefix = ref<string>('<strong>Custom bottom left attribution</strong>')

--- a/src/playground/views/ControlCustomMessageDemo.vue
+++ b/src/playground/views/ControlCustomMessageDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LControl, LMap, LTileLayer } from '../../components'
+import { LControl, LMap, LTileLayer } from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/playground/views/ControlDemo.vue
+++ b/src/playground/views/ControlDemo.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { LMap, LTileLayer, LControl } from '../../components'
+import { LMap, LTileLayer, LControl } from '@/maxel01/vue-leaflet'
 
 const clickHandler = () => {
     alert('and mischievous')

--- a/src/playground/views/ControlLayersDemo.vue
+++ b/src/playground/views/ControlLayersDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LControlLayers, LMap, LTileLayer } from '../../components'
+import { LControlLayers, LMap, LTileLayer } from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/playground/views/ControlScaleDemo.vue
+++ b/src/playground/views/ControlScaleDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LControlScale, LMap, LTileLayer } from '../../components'
+import { LControlScale, LMap, LTileLayer } from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/playground/views/ControlZoomDemo.vue
+++ b/src/playground/views/ControlZoomDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LControlZoom, LMap, LTileLayer } from '../../components'
+import { LControlZoom, LMap, LTileLayer } from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/playground/views/DemoHome.vue
+++ b/src/playground/views/DemoHome.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LMap, LTileLayer } from '../../components'
+import { LMap, LTileLayer } from '@/maxel01/vue-leaflet'
 import { ref } from 'vue'
 
 const zoom = ref<number>(2)

--- a/src/playground/views/FeatureGroupDemo.vue
+++ b/src/playground/views/FeatureGroupDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LFeatureGroup, LMap, LMarker, LTileLayer } from '../../components'
+import { LFeatureGroup, LMap, LMarker, LTileLayer } from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/playground/views/GeoJsonDemo.vue
+++ b/src/playground/views/GeoJsonDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LGeoJson, LMap, LTileLayer } from '../../components'
+import { LGeoJson, LMap, LTileLayer } from '@/maxel01/vue-leaflet'
 import { onMounted, ref } from 'vue'
 
 const geojson = ref(undefined)

--- a/src/playground/views/GridLayerDemo.vue
+++ b/src/playground/views/GridLayerDemo.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { h } from 'vue'
-import { LGridLayer, LMap, LTileLayer } from '../../components'
+import { LGridLayer, LMap, LTileLayer } from '@/maxel01/vue-leaflet'
 
 const childRender = (props) => () => {
     return h(

--- a/src/playground/views/IconDemo.vue
+++ b/src/playground/views/IconDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LIcon, LMap, LMarker, LTileLayer } from '../../components'
+import { LIcon, LMap, LMarker, LTileLayer } from '@/maxel01/vue-leaflet'
 import { computed, ref } from 'vue'
 import type { PointExpression } from 'leaflet'
 

--- a/src/playground/views/ImageOverlayDemo.vue
+++ b/src/playground/views/ImageOverlayDemo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
-import { LImageOverlay, LMap, LMarker, LPopup } from '../../components'
+import { LImageOverlay, LMap, LMarker, LPopup } from '@/maxel01/vue-leaflet'
 import { CRS, type LatLngBoundsLiteral } from 'leaflet'
 
 const imageOverlayUrl = ref(

--- a/src/playground/views/LayerGroupDemo.vue
+++ b/src/playground/views/LayerGroupDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LMap, LTileLayer, LLayerGroup, LMarker } from '../../components'
+import { LMap, LTileLayer, LLayerGroup, LMarker } from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/playground/views/MarkerDemo.vue
+++ b/src/playground/views/MarkerDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LMap, LMarker, LTileLayer } from '../../components'
+import { LMap, LMarker, LTileLayer } from '@/maxel01/vue-leaflet'
 import type { LatLngTuple } from 'leaflet'
 
 const coordinates: LatLngTuple = [50, 50]

--- a/src/playground/views/PolygonDemo.vue
+++ b/src/playground/views/PolygonDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LMap, LPolygon, LTileLayer } from '../../components'
+import { LMap, LPolygon, LTileLayer } from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/playground/views/PolylineDemo.vue
+++ b/src/playground/views/PolylineDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LMap, LPolyline, LTileLayer } from '../../components'
+import { LMap, LPolyline, LTileLayer } from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/playground/views/PopupDemo.vue
+++ b/src/playground/views/PopupDemo.vue
@@ -10,7 +10,7 @@ import {
     LPopup,
     LRectangle,
     LTileLayer
-} from '../../components'
+} from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/playground/views/RectangleDemo.vue
+++ b/src/playground/views/RectangleDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LMap, LRectangle, LTileLayer } from '../../components'
+import { LMap, LRectangle, LTileLayer } from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/playground/views/SVGOverlayDemo.vue
+++ b/src/playground/views/SVGOverlayDemo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
-import { LMap, LMarker, LPopup, LSVGOverlay } from '../../components'
+import { LMap, LMarker, LPopup, LSVGOverlay } from '@/maxel01/vue-leaflet'
 import { CRS, type LatLngBoundsLiteral } from 'leaflet'
 
 const width = ref(100)

--- a/src/playground/views/TileLayerDemo.vue
+++ b/src/playground/views/TileLayerDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LMap, LTileLayer } from '../../components'
+import { LMap, LTileLayer } from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/playground/views/TooltipDemo.vue
+++ b/src/playground/views/TooltipDemo.vue
@@ -10,7 +10,7 @@ import {
     LRectangle,
     LTileLayer,
     LTooltip
-} from '../../components'
+} from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/playground/views/VideoOverlayDemo.vue
+++ b/src/playground/views/VideoOverlayDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LMap, LTileLayer, LVideoOverlay } from '../../components'
+import { LMap, LTileLayer, LVideoOverlay } from '@/maxel01/vue-leaflet'
 
 /**
  * TODO Video doesn't seem to work in vitepress but works in playground.

--- a/src/playground/views/WmsTileLayerDemo.vue
+++ b/src/playground/views/WmsTileLayerDemo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LMap, LWmsTileLayer } from '../../components'
+import { LMap, LWmsTileLayer } from '@/maxel01/vue-leaflet'
 </script>
 
 <template>

--- a/src/types/interfaces/ILayerDefinition.ts
+++ b/src/types/interfaces/ILayerDefinition.ts
@@ -1,4 +1,4 @@
-import type { LayerType } from '../enums/LayerType.ts'
+import type { LayerType } from '../enums/LayerType'
 import { type Layer } from 'leaflet'
 
 export interface ILayerDefinition<T extends Layer = Layer> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 // REWRITE DONE
 import { type Evented, type LeafletEventHandlerFnMap } from 'leaflet'
 import { inject, type InjectionKey, provide, type Ref, ref, watch } from 'vue'
-import type { ComponentProps } from './functions/component.ts'
+import type { ComponentProps } from './functions/component'
 
 // BREAKING CHANGES: remove type Data
 export declare type ListenersAndAttrs = {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "extends": ["@vue/tsconfig/tsconfig.dom.json", "./tsconfig.json"],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,18 +1,16 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src"],
-  "exclude": ["src/playground"],
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/playground"
+  ],
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
     "declarationDir": "dist",
-    "baseUrl": ".",
     "composite": true,
-    "module": "ESNext",
-    "target": "ESNext",
-    "moduleResolution": "Node",
-    "strict": true,
-    "skipLibCheck": true,
-    "allowImportingTsExtensions": true
+    "module": "ESNext"
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,6 +11,5 @@
     "emitDeclarationOnly": true,
     "declarationDir": "dist",
     "composite": true,
-    "module": "ESNext"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,22 @@
 {
   "files": [],
   "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/maxel01/vue-leaflet": [
+        "src/lib"
+      ],
+      "@/*": [
+        "src/*"
+      ]
+    }
+  }
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2023",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,14 +4,13 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import dts from 'vite-plugin-dts'
 import terser from '@rollup/plugin-terser'
+import { alias } from './alias.config.js'
 
 // https://vite.dev/config/
 export default defineConfig({
     plugins: [vue(), dts({ tsconfigPath: './tsconfig.build.json' })],
     resolve: {
-        alias: {
-            '@': fileURLToPath(new URL('./src', import.meta.url))
-        }
+        alias
     },
     build: {
         lib: {


### PR DESCRIPTION
vue-leaflet used imports with the alias configuration.
In the beginning, I did not manage to get it working without generating errors. This is now fixed and the relative imports are replaced.