### PR TITLE
feat: add experimental flags and two new experimental features

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,20 +3,21 @@ import { alias } from '../../alias.config'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-    title: "Vue Leaflet",
-    description: "Documentation for the Vue Leaflet module",
+    title: 'Vue Leaflet',
+    description: 'Documentation for the Vue Leaflet module',
     head: [['link', { rel: 'icon', href: '/favicon.ico' }]],
     base: '/',
     vite: {
         resolve: {
             alias
-        },
+        }
     },
     themeConfig: {
         // https://vitepress.dev/reference/default-theme-config
         nav: [
             { text: 'Home', link: '/' },
             { text: 'Quick Start', link: '/getting-started/installation' },
+            { text: 'Guide', link: '/guide/using-l' },
             { text: 'Components', link: '/components/introduction' }
         ],
 
@@ -33,7 +34,8 @@ export default defineConfig({
                 items: [
                     { text: 'Using L', link: '/guide/using-l' },
                     { text: 'Accessing a map instance', link: '/guide/accessing-map-instance' },
-                    { text: 'Reactivity in vue-leaflet', link: '/guide/reactivity-leaflet' }
+                    { text: 'Reactivity in vue-leaflet', link: '/guide/reactivity-leaflet' },
+                    { text: 'Experimental Features', link: '/guide/experimental' }
                 ]
             },
             {
@@ -64,15 +66,15 @@ export default defineConfig({
                     { text: 'LTileLayer', link: '/components/l-tile-layer' },
                     { text: 'LTooltip', link: '/components/l-tooltip' },
                     { text: 'LVideoOverlay', link: '/components/l-video-overlay' },
-                    { text: 'LWmsTileLayer', link: '/components/l-wms-tile-layer' },
+                    { text: 'LWmsTileLayer', link: '/components/l-wms-tile-layer' }
                 ]
             },
             {
                 text: 'About',
                 items: [
-                    { text: 'Q&A', link: '/about/q&a' },
+                    { text: 'Q&A', link: '/about/q&a' }
                 ]
-            },
+            }
         ],
 
         socialLinks: [
@@ -81,7 +83,7 @@ export default defineConfig({
         ],
 
         search: {
-            provider: 'local',
+            provider: 'local'
         }
     },
     ignoreDeadLinks: true

--- a/docs/guide/experimental.md
+++ b/docs/guide/experimental.md
@@ -77,4 +77,4 @@ When using multiple components, the effect is even more significant: `TooltipDem
 
 ### useResetWebpackIcon
 
-Automatically resets Webpack icons (used for Leaflet's default markers). This was required in Leaflet v1, but it may no longer be necessary in v2. **If you use it, please create an issue or discussion to report whether it still works**.                                                 |
+Automatically resets Webpack icons (used for Leaflet's default markers). This was required in Leaflet v1, but it may no longer be necessary in v2. **If you use it, please create an issue or discussion to report whether it still works**.

--- a/docs/guide/experimental.md
+++ b/docs/guide/experimental.md
@@ -1,6 +1,10 @@
+---
+outline: [2,3]
+---
+
 # Experimental Features
 
-Our library provides a set of **experimental flags** to enable or disable certain features that are still under development. These flags are **optional** and grouped under the `experimental` namespace in the configuration.
+This library provides a set of **[experimental flags](#experimental-flags)** to enable or disable certain features that are still under development. These flags are **optional** and grouped under the `experimental` namespace in the configuration.
 
 ## Default Configuration
 
@@ -14,14 +18,9 @@ console.log(vueLeafletConfig.experimental)
 // }
 ```
 
-| Flag                | Description                                                                                                                                                                                                                                                                                  |
-| ------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| useResetWebpackIcon | Automatically resets Webpack icons (used for Leaflet's default markers). This was required in Leaflet v1, but it may no longer be necessary in v2. **If you use it, please create an issue or discussion to report whether it still works**.                                                 |
-| skipUndefinedProps  | The `propsBinder` utility binds every reactive property to a watcher (see [reactivity in vue-leaflet](./reactivity-leaflet)). When enabled, any props that are `undefined` will be skipped and will no longer be reactive. This reduces the number of watchers and **improves performance**. |
-
 ## Overriding Flags
 
-You can override the default values by calling `setLeafletConfig`:
+You can override the default values by calling `setVueLeafletConfig`:
 
 ```ts
 import { setVueLeafletConfig, vueLeafletConfig } from '@maxel01/vue-leaflet'
@@ -62,3 +61,20 @@ setVueLeafletConfig({
 
 * These flags are **experimental**: their behavior may change in future versions.
 * Top-level configuration options remain separate and are **not affected** by experimental flags.
+
+## Experimental Flags
+### skipUndefinedProps
+The `propsBinder` utility binds every reactive property to a watcher (see [reactivity in vue-leaflet](./reactivity-leaflet)). When enabled, any props that are `undefined` will be skipped and will no longer be reactive. This reduces the number of watchers and **improves performance**.
+
+#### Example
+The `DemoHome` component **has 14 watchers by default**:
+```vue
+<!--@include: ../../src/playground/views/DemoHome.vue -->
+```
+Enabling this feature reduces the number of watchers to **6**.
+
+When using multiple components, the effect is even more significant: `TooltipDemo` uses **22 components**, which normally leads to **176 watchers**, but only **37** when this flag is enabled.
+
+### useResetWebpackIcon
+
+Automatically resets Webpack icons (used for Leaflet's default markers). This was required in Leaflet v1, but it may no longer be necessary in v2. **If you use it, please create an issue or discussion to report whether it still works**.                                                 |

--- a/docs/guide/experimental.md
+++ b/docs/guide/experimental.md
@@ -1,0 +1,64 @@
+# Experimental Features
+
+Our library provides a set of **experimental flags** to enable or disable certain features that are still under development. These flags are **optional** and grouped under the `experimental` namespace in the configuration.
+
+## Default Configuration
+
+```ts
+import { vueLeafletConfig } from '@maxel01/vue-leaflet'
+
+console.log(vueLeafletConfig.experimental)
+// {
+//   useResetWebpackIcon: true,
+//   skipUndefinedProps: false
+// }
+```
+
+| Flag                | Description                                                                                                                                                                                                                                                                                  |
+| ------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| useResetWebpackIcon | Automatically resets Webpack icons (used for Leaflet's default markers). This was required in Leaflet v1, but it may no longer be necessary in v2. **If you use it, please create an issue or discussion to report whether it still works**.                                                 |
+| skipUndefinedProps  | The `propsBinder` utility binds every reactive property to a watcher (see [reactivity in vue-leaflet](./reactivity-leaflet)). When enabled, any props that are `undefined` will be skipped and will no longer be reactive. This reduces the number of watchers and **improves performance**. |
+
+## Overriding Flags
+
+You can override the default values by calling `setLeafletConfig`:
+
+```ts
+import { setVueLeafletConfig, vueLeafletConfig } from '@maxel01/vue-leaflet'
+
+setVueLeafletConfig({
+  experimental: {
+    skipUndefinedProps: false
+  }
+})
+
+console.log(vueLeafletConfig.experimental.skipUndefinedProps) // false
+```
+
+This allows you to safely enable or disable experimental behaviors **without affecting top-level configuration options**.
+
+## Example Usage
+
+```ts
+import { setVueLeafletConfig } from '@maxel01/vue-leaflet'
+
+// Enable one experimental feature
+setVueLeafletConfig({
+  experimental: {
+    useResetWebpackIcon: false
+  }
+})
+
+// Override both experimental flags at once
+setVueLeafletConfig({
+  experimental: {
+    useResetWebpackIcon: false,
+    skipUndefinedProps: false
+  }
+})
+```
+
+## Notes
+
+* These flags are **experimental**: their behavior may change in future versions.
+* Top-level configuration options remain separate and are **not affected** by experimental flags.

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,7 @@ export interface LeafletConfig {
 export const vueLeafletConfig: LeafletConfig = {
     experimental: {
         useResetWebpackIcon: true,
-        skipUndefinedProps: true
+        skipUndefinedProps: false
     }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,11 @@
 export interface ExperimentalFlags {
+    /**
+     * Automatically resets Webpack icons (used for Leaflet's default markers). This was required in Leaflet v1, but it may no longer be necessary in v2. **If you use it, please create an issue or discussion to report whether it still works**.
+     */
     useResetWebpackIcon: boolean
+    /**
+     * The `propsBinder` utility binds every reactive property to a watcher (see [reactivity in vue-leaflet](./reactivity-leaflet)). When enabled, any props that are `undefined` will be skipped and will no longer be reactive. This reduces the number of watchers and improves performance.
+     */
     skipUndefinedProps: boolean
 }
 
@@ -14,7 +20,7 @@ export const vueLeafletConfig: LeafletConfig = {
     }
 }
 
-export function setLeafletConfig(config: Partial<LeafletConfig>) {
+export function setVueLeafletConfig(config: Partial<LeafletConfig>) {
     Object.assign(vueLeafletConfig, config)
     vueLeafletConfig.experimental = {
         ...vueLeafletConfig.experimental,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,23 @@
+export interface ExperimentalFlags {
+    useResetWebpackIcon: boolean
+    skipUndefinedProps: boolean
+}
+
+export interface LeafletConfig {
+    experimental: ExperimentalFlags
+}
+
+export const vueLeafletConfig: LeafletConfig = {
+    experimental: {
+        useResetWebpackIcon: true,
+        skipUndefinedProps: true
+    }
+}
+
+export function setLeafletConfig(config: Partial<LeafletConfig>) {
+    Object.assign(vueLeafletConfig, config)
+    vueLeafletConfig.experimental = {
+        ...vueLeafletConfig.experimental,
+        ...config.experimental,
+    }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@
 import { type Evented, type LeafletEventHandlerFnMap } from 'leaflet'
 import { inject, type InjectionKey, provide, type Ref, ref, watch } from 'vue'
 import type { ComponentProps } from './functions/component'
+import { vueLeafletConfig } from '@/config'
 
 // BREAKING CHANGES: remove type Data
 export declare type ListenersAndAttrs = {
@@ -58,6 +59,7 @@ export const isFunction = (x: unknown) => typeof x === 'function'
  */
 export const propsBinder = (methods: Readonly<FunctionMap>, leafletElement: PropertyMap, props: Readonly<PropertyMap>) => {
     for (const key in props) {
+        if (vueLeafletConfig.experimental.skipUndefinedProps && props[key] === undefined) continue
         const setMethodName = 'set' + capitalizeFirstLetter(key)
         const setterMethod = methods[setMethodName]
         if (isFunction(setterMethod)) {
@@ -130,6 +132,7 @@ export const remapEvents = (contextAttrs: Record<string, unknown>): ListenersAnd
 // TODO It seems like Icon.Default is now IconDefault in leaflet v2
 export const resetWebpackIcon = async (Icon) => {
 //export const resetWebpackIcon = async (Icon: typeof IconDefault) => {
+    if (!vueLeafletConfig.experimental.useResetWebpackIcon) return
     const modules = await Promise.all([
         import('leaflet/dist/images/marker-icon-2x.png'),
         import('leaflet/dist/images/marker-icon.png'),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,6 +51,7 @@ export const capitalizeFirstLetter = (s: string) => {
 
 export const isFunction = (x: unknown) => typeof x === 'function'
 
+// const propsBinderScope = effectScope()
 /**
  * Sets up listeners for Vue component prop changes, so that we may correctly call the correct Leaflet on-change event handlers.
  * @param methods
@@ -58,6 +59,7 @@ export const isFunction = (x: unknown) => typeof x === 'function'
  * @param props the relevant Vue component props
  */
 export const propsBinder = (methods: Readonly<FunctionMap>, leafletElement: PropertyMap, props: Readonly<PropertyMap>) => {
+    //propsBinderScope.run(() => {
     for (const key in props) {
         if (vueLeafletConfig.experimental.skipUndefinedProps && props[key] === undefined) continue
         const setMethodName = 'set' + capitalizeFirstLetter(key)
@@ -83,6 +85,8 @@ export const propsBinder = (methods: Readonly<FunctionMap>, leafletElement: Prop
             console.warn(`No setter for '${key}'`)
         }
     }
+    //})
+    // propsBinderScope.log('Active watchers:', devScope.effects.length)
 }
 
 export const propsToLeafletOptions = <T extends object>(


### PR DESCRIPTION
resolves #46 

## Changes

- Introduced **experimental flags** support in the library.
- Added two new experimental features:
  1. `skipUndefinedProps`: Skips `undefined` props in `propsBinder`, reducing watchers and improving performance.
  2. `useResetWebpackIcon`: Automatically resets Webpack icons (used for Leaflet's default markers).
- Updated documentation with usage examples for both features.

## Motivation

These changes allow developers to opt-in to experimental optimizations, improving performance for applications with many reactive components while keeping the library backwards-compatible.

## Notes

- Flags are optional; default behavior remains unchanged.
- This PR addresses #30 only in an *experimental* way and does **not** fully close it.
