### PR TITLE
fix(build): remove terser plugin to allow tree-shaking again

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@release-it/conventional-changelog": "^8.0.2",
-    "@rollup/plugin-terser": "^0.4.4",
     "@types/geojson": "^7946.0.16",
     "@types/leaflet": "^1.9.20",
     "@types/node": "^24.0.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ importers:
       '@release-it/conventional-changelog':
         specifier: ^8.0.2
         version: 8.0.2(release-it@17.11.0(typescript@5.8.3))
-      '@rollup/plugin-terser':
-        specifier: ^0.4.4
-        version: 0.4.4(rollup@4.45.0)
       '@types/geojson':
         specifier: ^7946.0.16
         version: 7946.0.16

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,6 @@ import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import dts from 'vite-plugin-dts'
-import terser from '@rollup/plugin-terser'
 import { alias } from './alias.config.js'
 
 // https://vite.dev/config/
@@ -28,7 +27,6 @@ export default defineConfig({
                     leaflet: 'L'
                 }
             },
-            plugins: [terser()]
         }
     }
 })


### PR DESCRIPTION
The Terser plugin appears to compress the file too aggressively. Without it, Vite doesn't remove comments in the library build.

In my tests, I noticed that the build size increased from 7.9 KB to 9.3 KB when Terser was removed. However, when analyzing the final Nuxt build using nuxt analyze, the reported size was identical. This suggests that comments were still removed — likely during Nuxt’s own minification process
