### PR TITLE
fix: revert change from #37 in utils.ts which caused a lost context when calling the setter method of a leaflet object.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,12 +73,11 @@ export const propsBinder = (methods: Readonly<FunctionMap>, leafletElement: Prop
             )
             continue
         }
-        const leafletElementSetter = leafletElement[setMethodName]
-        if (isFunction(leafletElementSetter)) {
+        if (isFunction(leafletElement[setMethodName])) {
             watch(
                 () => props[key],
                 (newVal) => {
-                    leafletElementSetter(newVal)
+                    leafletElement[setMethodName](newVal)
                 }
             )
         } else if (key !== 'options' && import.meta.env.vitest) {


### PR DESCRIPTION
Extracting the method from a class results in a lost context. This caused a severe bug which is fixed now.
See #37