### PR TITLE
fix(docs): demo and src are working in `getting-started/usage`

### DIFF
--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -9,7 +9,7 @@ Vue Leaflet is a module that provides a set of components to work with Leaflet i
 Here is a basic example of how to use the `LMap` and `LTileLayer` components to display a map :
 
 ```vue{2,5,9-15}
-<!--@include: ../../src/playground/views/DemoHome.vue -->
+<!--@include: ../../playground/app/pages/index.vue -->
 ```
 
 And here is how it should look :
@@ -19,5 +19,5 @@ import "leaflet/dist/leaflet.css";
 </script>
 
 <div class="demo">
-    <DemoHome />
+    <demo-index />
 </div>


### PR DESCRIPTION
The usage page had the wrong path to the vue file and the wrong demo component name.
These have been replaced and the usage page is fully working.