### PR TITLE
fix(LIcon): LIcon uses Icon instead of DivIcon if the slot is empty

### DIFF
--- a/src/components/LIcon.vue
+++ b/src/components/LIcon.vue
@@ -111,7 +111,7 @@ function useCreateIcon() {
 <template>
     <div ref="root">
         <!--
-        @slot Slot content will be rendered inside the Leaflet icon container. Use this slot to inject custom HTML or Vue components into the icon, such as labels, SVGs, or interactive elements.
+        @slot Slot content will be rendered inside the Leaflet icon container. Use this slot to inject custom HTML or Vue components into the icon, such as labels, SVGs, or interactive elements. This will use `DivIcon` instead of `Icon`.
         -->
         <slot />
     </div>

--- a/src/components/LIcon.vue
+++ b/src/components/LIcon.vue
@@ -69,7 +69,7 @@ function useCreateIcon() {
     let iconObject: Icon | DivIcon | undefined = undefined
 
     const createIcon = (el: HTMLElement, recreationNeeded: boolean, htmlSwapNeeded: boolean) => {
-        const elHtml = el && el.innerHTML
+        const elHtml = el && el.innerHTML.replace(new RegExp("<!--[\\s\\S]*?-->", "g"), "")
         if (!recreationNeeded) {
             if (htmlSwapNeeded && iconObject && canSetParentHtml()) {
                 setParentHtml(elHtml)


### PR DESCRIPTION
``el.innerHtml`` returns the content of the element including the documentation comment. As the Element was not empty ``DivIcon`` was used instead of ``Icon``.