### PR TITLE
refactor: add generics to all `Props` and `Emits`

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -38,7 +38,7 @@ import {
     RegisterLayerControlInjection,
     RemoveLayerInjection
 } from '@/types/injectionKeys'
-import { type MapProps, mapPropsDefaults, setupMap } from '@/functions/map'
+import { type MapEmits, type MapProps, mapPropsDefaults, setupMap } from '@/functions/map'
 
 /**
  * > Base component, contains and wraps all the other components.
@@ -53,24 +53,7 @@ const { methods, layersInControl } = useMethods()
 const { listeners, attrs, eventHandlers } = useEvents()
 useProvideFunctions()
 
-const emit = defineEmits<{
-    /**
-     * Triggers when the component is ready
-     */
-    (event: 'ready', map: Map): void
-    /**
-     * Triggers when the map's zoom level changes.
-     */
-    (event: 'update:zoom', zoom: number): void
-    /**
-     * Triggers when the map's center coordinates are updated.
-     */
-    (event: 'update:center', center: LatLng): void
-    /**
-     * Triggers when the map's visible bounds are updated.
-     */
-    (event: 'update:bounds', center: LatLngBounds): void
-}>()
+const emit = defineEmits<MapEmits>()
 
 defineExpose({
     /**

--- a/src/functions/circle.ts
+++ b/src/functions/circle.ts
@@ -10,7 +10,7 @@ import {
 } from './circleMarker'
 import type { Ref } from 'vue'
 
-export interface CircleProps extends CircleMarkerProps<CircleOptions> {
+export interface CircleProps<T extends CircleOptions = CircleOptions> extends CircleMarkerProps<T> {
     /**
      * Radius of the circle, in meters
      * @reactive
@@ -22,7 +22,8 @@ export const circlePropsDefaults = {
     ...circleMarkerPropsDefaults
 }
 
-export type CircleEmits = CircleMarkerEmits<Circle>
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+export interface CircleEmits<T extends Circle = Circle> extends CircleMarkerEmits<T> {}
 
 export const setupCircle = (
     props: CircleProps,

--- a/src/functions/control.ts
+++ b/src/functions/control.ts
@@ -14,7 +14,8 @@ export interface ControlAbstractProps<T extends ControlOptions = ControlOptions>
     position?: ControlPosition
 }
 
-export interface ControlProps extends ControlAbstractProps {
+export interface ControlProps<T extends ControlOptions = ControlOptions>
+    extends ControlAbstractProps<T> {
     /**
      * Adds stopPropagation to the element's `click`, `dblclick`, `contextmenu` and `pointerdown` events (plus browser variants).
      * @initOnly

--- a/src/functions/controlAttribution.ts
+++ b/src/functions/controlAttribution.ts
@@ -10,7 +10,9 @@ import {
 } from './control'
 import type { Ref } from 'vue'
 
-export interface ControlAttributionProps extends ControlAbstractProps<Control.AttributionOptions> {
+export interface ControlAttributionProps<
+    T extends Control.AttributionOptions = Control.AttributionOptions
+> extends ControlAbstractProps<T> {
     /**
      * The HTML text shown before the attributions. Pass `false` to disable.
      * @reactive
@@ -22,7 +24,9 @@ export const controlAttributionPropsDefaults = {
     ...controlAbstractPropsDefaults
 }
 
-export type ControlAttributionEmits = ControlEmits<Control.Attribution>
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+export interface ControlAttributionEmits<T extends Control.Attribution = Control.Attribution>
+    extends ControlEmits<T> {}
 
 export const setupControlAttribution = (
     props: ControlAttributionProps,

--- a/src/functions/controlLayers.ts
+++ b/src/functions/controlLayers.ts
@@ -11,7 +11,8 @@ import {
 import type { Ref } from 'vue'
 import type { ILayerDefinition } from '@/types/interfaces'
 
-export interface ControlLayersProps extends ControlAbstractProps<Control.LayersOptions> {
+export interface ControlLayersProps<T extends Control.LayersOptions = Control.LayersOptions>
+    extends ControlAbstractProps<T> {
     /**
      * If `true`, the control will be collapsed into an icon and expanded on mouse hover, touch, or keyboard activation.
      * @initOnly
@@ -47,7 +48,9 @@ export const controlLayersPropsDefaults = {
     sortLayers: undefined
 }
 
-export type ControlLayersEmits = ControlEmits<Control.Layers>
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+export interface ControlLayersEmits<T extends Control.Layers = Control.Layers>
+    extends ControlEmits<T> {}
 
 export const setupControlLayers = (
     props: ControlLayersProps,

--- a/src/functions/controlScale.ts
+++ b/src/functions/controlScale.ts
@@ -10,7 +10,8 @@ import {
 } from './control'
 import type { Ref } from 'vue'
 
-export interface ControlScaleProps extends ControlAbstractProps<Control.ScaleOptions> {
+export interface ControlScaleProps<T extends Control.ScaleOptions = Control.ScaleOptions>
+    extends ControlAbstractProps<T> {
     /**
      * Maximum width of the control in pixels. The width is set dynamically to show round values (eg. 100, 200, 500).
      * @initOnly
@@ -40,7 +41,9 @@ export const controlScalePropsDefaults = {
     updateWhenIdle: undefined
 }
 
-export type ControlScaleEmits = ControlEmits<Control.Scale>
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+export interface ControlScaleEmits<T extends Control.Scale = Control.Scale>
+    extends ControlEmits<T> {}
 
 export const setupControlScale = (
     props: ControlScaleProps,

--- a/src/functions/controlZoom.ts
+++ b/src/functions/controlZoom.ts
@@ -10,7 +10,8 @@ import {
 } from './control'
 import type { Ref } from 'vue'
 
-export interface ControlZoomProps extends ControlAbstractProps<Control.ZoomOptions> {
+export interface ControlZoomProps<T extends Control.ZoomOptions = Control.ZoomOptions>
+    extends ControlAbstractProps<T> {
     /**
      * The text set on the 'zoom in' button
      * @initOnly
@@ -37,7 +38,8 @@ export const controlZoomPropsDefaults = {
     ...controlAbstractPropsDefaults
 }
 
-export type ControlZoomEmits = ControlEmits<Control.Zoom>
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+export interface ControlZoomEmits<T extends Control.Zoom = Control.Zoom> extends ControlEmits<T> {}
 
 export const setupControlZoom = (
     props: ControlZoomProps,

--- a/src/functions/geoJSON.ts
+++ b/src/functions/geoJSON.ts
@@ -11,7 +11,8 @@ import {
     setupLayerGroup
 } from './layerGroup'
 
-export interface GeoJSONProps extends LayerGroupProps<GeoJSONOptions> {
+export interface GeoJSONProps<T extends GeoJSONOptions = GeoJSONOptions>
+    extends LayerGroupProps<T> {
     /**
      * An object in GeoJSON format to display on the map (you can alternatively add it later with addData method).
      * @reactive
@@ -26,7 +27,8 @@ export interface GeoJSONProps extends LayerGroupProps<GeoJSONOptions> {
 
 export const geoJSONPropsDefaults = layerGroupPropsDefaults
 
-export type GeoJSONEmits = LayerGroupEmits<GeoJSON>
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+export interface GeoJSONEmits<T extends GeoJSON = GeoJSON> extends LayerGroupEmits<T> {}
 
 export const setupGeoJSON = (
     props: GeoJSONProps,

--- a/src/functions/icon.ts
+++ b/src/functions/icon.ts
@@ -1,7 +1,7 @@
 import type { DivIconOptions, PointExpression } from 'leaflet'
 import { type ComponentProps, componentPropsDefaults } from '@/functions/component'
 
-export interface IconProps extends ComponentProps<DivIconOptions> {
+export interface IconProps<T extends DivIconOptions = DivIconOptions> extends ComponentProps<T> {
     /**
      * The URL to the icon image (absolute or relative to your script path).
      * @reactive

--- a/src/functions/imageOverlay.ts
+++ b/src/functions/imageOverlay.ts
@@ -54,7 +54,8 @@ export interface ImageOverlayAbstractProps<T extends ImageOverlayOptions = Image
     bounds: LatLngBoundsExpression
 }
 
-export interface ImageOverlayProps extends ImageOverlayAbstractProps {
+export interface ImageOverlayProps<T extends ImageOverlayOptions = ImageOverlayOptions>
+    extends ImageOverlayAbstractProps<T> {
     /**
      * Url of the image
      * @reactive

--- a/src/functions/interactiveLayer.ts
+++ b/src/functions/interactiveLayer.ts
@@ -26,7 +26,8 @@ export const interactiveLayerPropsDefaults = {
     bubblingMouseEvents: undefined
 }
 
-export type InteractiveLayerEmits = LayerEmits
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+export interface InteractiveLayerEmits extends LayerEmits {}
 
 export const setupInteractiveLayer = (
     props: InteractiveLayerProps,

--- a/src/functions/map.ts
+++ b/src/functions/map.ts
@@ -1,7 +1,7 @@
-import { type CRS, LatLngBounds, type MapOptions, type PointExpression } from 'leaflet'
+import { type CRS, LatLng, LatLngBounds, Map, type MapOptions, type PointExpression } from 'leaflet'
 import { type ComponentProps, componentPropsDefaults, setupComponent } from '@/functions/component'
 
-export interface MapProps extends ComponentProps<MapOptions> {
+export interface MapProps<T extends MapOptions = MapOptions> extends ComponentProps<T> {
     /**
      * The width of the map
      * @reactive native
@@ -134,6 +134,25 @@ export const mapPropsDefaults = {
     fadeAnimation: undefined,
     markerZoomAnimation: undefined,
     noBlockingAnimations: undefined
+}
+
+export interface MapEmits<T extends Map = Map> {
+    /**
+     * Triggers when the component is ready
+     */
+    (event: 'ready', map: T): void
+    /**
+     * Triggers when the map's zoom level changes.
+     */
+    (event: 'update:zoom', zoom: number): void
+    /**
+     * Triggers when the map's center coordinates are updated.
+     */
+    (event: 'update:center', center: LatLng): void
+    /**
+     * Triggers when the map's visible bounds are updated.
+     */
+    (event: 'update:bounds', center: LatLngBounds): void
 }
 
 export const setupMap = (props: MapProps) => {

--- a/src/functions/marker.ts
+++ b/src/functions/marker.ts
@@ -7,7 +7,7 @@ import { propsToLeafletOptions } from '@/utils'
 const unrenderedContentTypes = ['Symbol(Comment)', 'Symbol(Text)']
 const unrenderedComponentNames = ['LTooltip', 'LPopup']
 
-export interface MarkerProps extends LayerProps<MarkerOptions> {
+export interface MarkerProps<T extends MarkerOptions = MarkerOptions> extends LayerProps<T> {
     /**
      * Whether the marker is draggable with mouse/touch or not.
      * @reactive
@@ -35,11 +35,11 @@ export const markerPropsDefaults = {
     draggable: undefined
 }
 
-export interface MarkerEmits extends LayerEmits {
+export interface MarkerEmits<T extends Marker = Marker> extends LayerEmits {
     /**
      * Triggers when the component is ready
      */
-    (event: 'ready', marker: Marker): void
+    (event: 'ready', marker: T): void
     /**
      * Triggers when the latLng prop needs to be updated
      */

--- a/src/functions/path.ts
+++ b/src/functions/path.ts
@@ -83,7 +83,8 @@ export const pathPropsDefaults = {
     fill: undefined
 }
 
-export type PathEmits = InteractiveLayerEmits
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+export interface PathEmits extends InteractiveLayerEmits {}
 
 export const setupPath = (props: PathProps, leafletRef: Ref<Path | undefined>, emit: PathEmits) => {
     const { options: interactiveLayerOptions, methods: interactiveLayerMethods } =

--- a/src/functions/polygon.ts
+++ b/src/functions/polygon.ts
@@ -11,7 +11,8 @@ import {
 import type { Ref } from 'vue'
 
 /* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
-export interface PolygonAbstractProps extends PolylineAbstractProps {}
+export interface PolygonAbstractProps<T extends PolylineOptions = PolylineOptions>
+    extends PolylineAbstractProps<T> {}
 
 export interface PolygonProps extends PolygonAbstractProps {
     /**

--- a/src/functions/popup.ts
+++ b/src/functions/popup.ts
@@ -3,7 +3,7 @@ import type { Ref } from 'vue'
 
 import { type PopperProps, popperPropsDefaults, setupPopper } from './popper'
 
-export interface PopupProps extends PopperProps<PopupOptions> {
+export interface PopupProps<T extends PopupOptions = PopupOptions> extends PopperProps<T> {
     /**
      * The position of the popup
      * @reactive

--- a/src/functions/rectangle.ts
+++ b/src/functions/rectangle.ts
@@ -15,7 +15,8 @@ import {
 } from './polygon'
 import type { Ref } from 'vue'
 
-export interface RectangleProps extends PolygonAbstractProps {
+export interface RectangleProps<T extends PolylineOptions = PolylineOptions>
+    extends PolygonAbstractProps<T> {
     /**
      * Array of coordinates objects that represent the rectangle
      * @reactive
@@ -32,7 +33,8 @@ export const rectanglePropsDefaults = {
     ...polygonPropsDefaults
 }
 
-export type RectangleEmits = PolygonEmits<Rectangle>
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+export interface RectangleEmits<T extends Rectangle = Rectangle> extends PolygonEmits<T> {}
 
 export const setupRectangle = (
     props: RectangleProps,

--- a/src/functions/svgOverlay.ts
+++ b/src/functions/svgOverlay.ts
@@ -6,7 +6,8 @@ import { propsToLeafletOptions } from '@/utils'
 import type { ImageOverlayAbstractProps, ImageOverlayEmits } from './imageOverlay'
 import { imageOverlayPropsDefaults, setupImageOverlay } from './imageOverlay'
 
-export interface SVGOverlayProps extends ImageOverlayAbstractProps {
+export interface SVGOverlayProps<T extends ImageOverlayOptions = ImageOverlayOptions>
+    extends ImageOverlayAbstractProps<T> {
     /**
      * Url of the svg or the SVGElement
      * @initOnly
@@ -18,7 +19,8 @@ export const svgOverlayPropsDefaults = {
     ...imageOverlayPropsDefaults
 }
 
-export type SVGOverlayEmits = ImageOverlayEmits<SVGOverlay>
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+export interface SVGOverlayEmits<T extends SVGOverlay = SVGOverlay> extends ImageOverlayEmits<T> {}
 
 export const setupSVGOverlay = (
     props: SVGOverlayProps,

--- a/src/functions/tileLayer.ts
+++ b/src/functions/tileLayer.ts
@@ -38,7 +38,8 @@ export const tileLayerPropsDefaults = {
     detectRetina: undefined
 }
 
-export type TileLayerEmits<T extends TileLayer = TileLayer> = GridLayerEmits<T>
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+export interface TileLayerEmits<T extends TileLayer = TileLayer> extends GridLayerEmits<T> {}
 
 export const setupTileLayer = <T extends TileLayer>(
     props: TileLayerProps,

--- a/src/functions/tooltip.ts
+++ b/src/functions/tooltip.ts
@@ -7,7 +7,7 @@ import { type PopperProps, popperPropsDefaults, setupPopper } from './popper'
 import type { Tooltip, TooltipOptions } from 'leaflet'
 
 /* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
-export interface TooltipProps extends PopperProps<TooltipOptions> {}
+export interface TooltipProps<T extends TooltipOptions = TooltipOptions> extends PopperProps<T> {}
 
 export const tooltipPropsDefaults = {
     ...popperPropsDefaults

--- a/src/functions/videoOverlay.ts
+++ b/src/functions/videoOverlay.ts
@@ -5,7 +5,8 @@ import { propsToLeafletOptions } from '@/utils'
 import type { ImageOverlayAbstractProps, ImageOverlayEmits } from './imageOverlay'
 import { imageOverlayPropsDefaults, setupImageOverlay } from './imageOverlay'
 
-export interface VideoOverlayProps extends ImageOverlayAbstractProps<VideoOverlayOptions> {
+export interface VideoOverlayProps<T extends VideoOverlayOptions = VideoOverlayOptions>
+    extends ImageOverlayAbstractProps<T> {
     /**
      * Url of the video, urls of the videos or a video Element
      * @initOnly
@@ -17,7 +18,9 @@ export const videoOverlayPropsDefaults = {
     ...imageOverlayPropsDefaults
 }
 
-export type VideoOverlayEmits = ImageOverlayEmits<VideoOverlay>
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+export interface VideoOverlayEmits<T extends VideoOverlay = VideoOverlay>
+    extends ImageOverlayEmits<T> {}
 
 export const setupVideoOverlay = (
     props: VideoOverlayProps,

--- a/src/functions/wmsTileLayer.ts
+++ b/src/functions/wmsTileLayer.ts
@@ -10,7 +10,7 @@ import {
 } from './tileLayer'
 import type { Ref } from 'vue'
 
-export interface WmsTileLayerProps extends TileLayerProps<WMSOptions> {
+export interface WmsTileLayerProps<T extends WMSOptions = WMSOptions> extends TileLayerProps<T> {
     /**
      * Comma-separated list of WMS layers to show
      * @initOnly
@@ -54,7 +54,9 @@ export const wmsTileLayerPropsDefaults = {
     uppercase: undefined
 }
 
-export type WmsTileLayerEmits = TileLayerEmits<TileLayer.WMS>
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type */
+export interface WmsTileLayerEmits<T extends TileLayer.WMS = TileLayer.WMS>
+    extends TileLayerEmits<T> {}
 
 export const setupWMSTileLayer = (
     props: WmsTileLayerProps,


### PR DESCRIPTION
All ``Props`` and ``Emits`` now have generics. This simplifies the extension of existing components in the `vue-leaflet-plugins` wrapper.