### PR TITLE
feat(LSVGOverlay): add slot for the `SVGElement`

### DIFF
--- a/playground/app/pages/svg-overlay.vue
+++ b/playground/app/pages/svg-overlay.vue
@@ -7,13 +7,13 @@ import { CRS, type LatLngBoundsLiteral } from 'leaflet'
 const width = ref(100)
 const height = ref(100)
 
-const svgElement = ref()
+/* const svgElement = ref()
 onMounted(() => {
     svgElement.value = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
     svgElement.value.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
     svgElement.value.setAttribute('viewBox', '0 0 200 200')
     svgElement.value.innerHTML = '<rect width="200" height="200"/><rect x="75" y="23" width="50" height="50" style="fill:red"/><rect x="75" y="123" width="50" height="50" style="fill:#0013ff"/>'
-})
+}) */
 
 const bounds = computed(
     () =>
@@ -37,7 +37,16 @@ const markers = ref([
 
 <template>
     <LMap :zoom="1" :crs="CRS.Simple" :center="[height / 2, width / 2]" :minZoom="-5">
-        <LSVGOverlay v-if="svgElement" :svg="svgElement" :bounds="bounds" />
+        <!--LSVGOverlay v-if="svgElement" :svg="svgElement" :bounds="bounds"-->
+        <LSVGOverlay :bounds="bounds">
+            <template #svg>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+                    <rect width="200" height="200" />
+                    <rect x="75" y="23" width="50" height="50" style="fill: red" />
+                    <rect x="75" y="123" width="50" height="50" style="fill: #0013ff" />
+                </svg>
+            </template>
+        </LSVGOverlay>
 
         <LMarker v-for="(marker, idx) in markers" :key="idx" :lat-lng="marker.coordinates">
             <LPopup>{{ idx }}</LPopup>

--- a/src/components/LSVGOverlay.vue
+++ b/src/components/LSVGOverlay.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { SVGOverlay } from 'leaflet'
-import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
+import { markRaw, nextTick, onMounted, ref, useAttrs, computed } from 'vue'
 import { AddLayerInjection } from '@/types/injectionKeys'
 import { assertInject, propsBinder, remapEvents } from '@/utils'
 import {
@@ -12,13 +12,13 @@ import {
 
 /**
  * > Used to load and display a single svg over specific bounds of the map.
- * @demo svg-overlay {7-24,40}
+ * @demo svg-overlay {7-24,40-49}
  */
 defineOptions({})
 const props = withDefaults(defineProps<SVGOverlayProps>(), svgOverlayPropsDefaults)
 const emit = defineEmits<SVGOverlayEmits>()
 
-const { ready, leafletObject } = useSVGOverlay()
+const { ready, leafletObject, svgRoot } = useSVGOverlay()
 defineExpose({
     /**
      * Indicates whether the component and its underlying Leaflet object are fully initialized.
@@ -35,13 +35,24 @@ defineExpose({
 function useSVGOverlay() {
     const leafletObject = ref<SVGOverlay>()
     const ready = ref(false)
+    const svgRoot = ref<HTMLDivElement>()
+    const svg = computed<SVGElement | undefined>(() => {
+        const svg = svgRoot.value?.firstElementChild
+        return svg?.tagName === 'svg' ? (svg as SVGElement) : undefined
+    })
 
     const addLayer = assertInject(AddLayerInjection)
 
     const { options, methods } = setupSVGOverlay(props, leafletObject, emit)
 
     onMounted(async () => {
-        leafletObject.value = markRaw<SVGOverlay>(new SVGOverlay(props.svg, props.bounds, options))
+        if (!svg.value && !props.svg) {
+            console.warn('Missing svg prop or slot: LSVGOverlay has not been created.')
+            return
+        }
+        leafletObject.value = markRaw<SVGOverlay>(
+            new SVGOverlay(svg.value ? svg.value : props.svg!, props.bounds, options)
+        )
 
         const { listeners } = remapEvents(useAttrs())
         leafletObject.value.on(listeners)
@@ -55,7 +66,7 @@ function useSVGOverlay() {
         nextTick(() => emit('ready', leafletObject.value!))
     })
 
-    return { ready, leafletObject }
+    return { ready, leafletObject, svgRoot }
 }
 </script>
 
@@ -65,5 +76,11 @@ function useSVGOverlay() {
        @slot Used to inject Leaflet child components like `<LPopup>` or `<LTooltip>` into the `LCircleMarker`.
        -->
         <slot />
+    </div>
+    <div style="display: none" ref="svgRoot">
+        <!--
+       @slot Place your `SVGElement` inside this slot. Be aware that `props.svg` will be ignored, when this slot is used. Changes inside the `SVGElement` are reactive. However, replacing the `SVGElement` is not reactive.
+       -->
+        <slot name="svg" />
     </div>
 </template>

--- a/src/functions/svgOverlay.ts
+++ b/src/functions/svgOverlay.ts
@@ -9,10 +9,10 @@ import { imageOverlayPropsDefaults, setupImageOverlay } from './imageOverlay'
 export interface SVGOverlayProps<T extends ImageOverlayOptions = ImageOverlayOptions>
     extends ImageOverlayAbstractProps<T> {
     /**
-     * Url of the svg or the SVGElement
+     * Url of the svg or the SVGElement. Will be ignored when using the named slot `svg`.
      * @initOnly
      */
-    svg: string | SVGElement
+    svg?: string | SVGElement
 }
 
 export const svgOverlayPropsDefaults = {

--- a/tests/unit/components/LSVGOverlay.test.ts
+++ b/tests/unit/components/LSVGOverlay.test.ts
@@ -1,5 +1,5 @@
 import { flushPromises, shallowMount, type VueWrapper } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { AddLayerInjection, RemoveLayerInjection } from '@/types/injectionKeys'
 import { testRemoveLayerOnUnmount } from '@/tests/helper/tests'
 import {
@@ -41,6 +41,7 @@ describe('LSVGOverlay.vue', () => {
     testRemoveLayerOnUnmount(createWrapper)
 
     testCorrectInitialisation(createWrapper)
+    testWarnings(createWrapper)
     testAddLayer(createWrapper)
 })
 
@@ -51,5 +52,17 @@ const testCorrectInitialisation = (getWrapper: () => Promise<VueWrapper<any>>) =
 
         expect(obj).toBeDefined()
         expect(obj.options).toBeDefined()
+    })
+    it('creates a Leaflet svg overlay with the svg slot and correct options', async () => {
+        // TEST add test with slots
+    })
+}
+
+const testWarnings = (getWrapper: (props: object) => Promise<VueWrapper<any>>) => {
+    it('it logs an error when props.svg and the svg slot are invalid', async () => {
+        const consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const wrapper = await getWrapper({svg: undefined})
+        expect(consoleWarnMock).toHaveBeenCalledExactlyOnceWith('Missing svg prop or slot: LSVGOverlay has not been created.')
+        expect(wrapper.vm.leafletObject).toBeUndefined()
     })
 }


### PR DESCRIPTION
The LSVGOverlay can now instantiate the svg with a dedicated slot.