### PR TITLE
feat(LVideoOverlay): add slot for the `HtmlVideoElement`

### DIFF
--- a/playground/app/pages/video-overlay.vue
+++ b/playground/app/pages/video-overlay.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
 import { LMap, LTileLayer, LVideoOverlay } from '@maxel01/vue-leaflet'
+import { LatLngBounds } from 'leaflet'
 
 /**
  * TODO Video doesn't seem to work in vitepress but works in playground.
  */
 const videoUrl = 'https://www.mapbox.com/bites/00188/patricia_nasa.webm'
-const videoBounds = [
+const videoBounds = new LatLngBounds([
     [32, -130],
     [13, -100]
-]
+])
 </script>
 
 <template>
@@ -18,6 +19,6 @@ const videoBounds = [
             layer-type="base"
             name="OpenStreetMap"
         />
-        <LVideoOverlay :video="videoUrl" :bounds="videoBounds"/>
+        <LVideoOverlay :video="videoUrl" :bounds="videoBounds" />
     </LMap>
 </template>

--- a/src/functions/videoOverlay.ts
+++ b/src/functions/videoOverlay.ts
@@ -8,10 +8,10 @@ import { imageOverlayPropsDefaults, setupImageOverlay } from './imageOverlay'
 export interface VideoOverlayProps<T extends VideoOverlayOptions = VideoOverlayOptions>
     extends ImageOverlayAbstractProps<T> {
     /**
-     * Url of the video, urls of the videos or a video Element
+     * Url of the video, urls of the videos or a video Element. Will be ignored when using the named slot `video`.
      * @initOnly
      */
-    video: string | string[] | HTMLVideoElement
+    video?: string | string[] | HTMLVideoElement
 }
 
 export const videoOverlayPropsDefaults = {

--- a/tests/unit/components/LVideoOverlay.test.ts
+++ b/tests/unit/components/LVideoOverlay.test.ts
@@ -1,5 +1,5 @@
 import { flushPromises, shallowMount, type VueWrapper } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { AddLayerInjection, RemoveLayerInjection } from '@/types/injectionKeys'
 import { testRemoveLayerOnUnmount } from '@/tests/helper/tests'
 import {
@@ -41,6 +41,7 @@ describe('LVideoOverlay.vue', () => {
     testRemoveLayerOnUnmount(createWrapper)
 
     testCorrectInitialisation(createWrapper)
+    testWarnings(createWrapper)
     testAddLayer(createWrapper)
 })
 
@@ -51,5 +52,19 @@ const testCorrectInitialisation = (getWrapper: () => Promise<VueWrapper<any>>) =
 
         expect(obj).toBeDefined()
         expect(obj.options).toBeDefined()
+    })
+    it('creates a Leaflet video overlay with the video slot and correct options', async () => {
+        // TEST add test with slots
+    })
+}
+
+const testWarnings = (getWrapper: (props: object) => Promise<VueWrapper<any>>) => {
+    it('it logs an error when props.video and the video slot are invalid', async () => {
+        const consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const wrapper = await getWrapper({ video: undefined })
+        expect(consoleWarnMock).toHaveBeenCalledExactlyOnceWith(
+            'Missing video prop or slot: VideoOverlay has not been created.'
+        )
+        expect(wrapper.vm.leafletObject).toBeUndefined()
     })
 }


### PR DESCRIPTION
The LVideoOverlay can now instantiate the video with a dedicated slot.

see #92