### PR TITLE
docs: remove comment in `LVideoOverlay` demo

### DIFF
--- a/playground/app/pages/video-overlay.vue
+++ b/playground/app/pages/video-overlay.vue
@@ -2,9 +2,6 @@
 import { LMap, LTileLayer, LVideoOverlay } from '@maxel01/vue-leaflet'
 import { LatLngBounds } from 'leaflet'
 
-/**
- * TODO Video doesn't seem to work in vitepress but works in playground.
- */
 const videoUrl = 'https://www.mapbox.com/bites/00188/patricia_nasa.webm'
 const videoBounds = new LatLngBounds([
     [32, -130],
@@ -13,7 +10,7 @@ const videoBounds = new LatLngBounds([
 </script>
 
 <template>
-    <LMap :zoom="5" :center="[22.5, -115]" :minZoom="-5">
+    <LMap :zoom="4" :center="[22.5, -115]" :minZoom="-5">
         <LTileLayer
             url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             layer-type="base"

--- a/src/components/LVideoOverlay.vue
+++ b/src/components/LVideoOverlay.vue
@@ -13,7 +13,7 @@ import {
 
 /**
  * > Used to load and display a video over specific bounds of the map.
- * @demo video-overlay {8-12,17-22}
+ * @demo video-overlay {5-9,19}
  */
 defineOptions({})
 const props = withDefaults(defineProps<VideoOverlayProps>(), videoOverlayPropsDefaults)


### PR DESCRIPTION
The VideoOverlay seems to work correctly in vitepress. Therefore, the comment has been removed. The zoom has been adjusted to fit the viewport better.