### PR TITLE
refactor(interactiveLayer): rename `bubblingMouseEvents` to `bubblingPointerEvents`

### DIFF
--- a/docs/getting-started/migration.md
+++ b/docs/getting-started/migration.md
@@ -13,6 +13,8 @@ Leaflet released a new [major version](https://leafletjs.com/2025/05/18/leaflet-
   - is not necessary with leaflet v2 and ESM support
 - core: remove type `Data` from `utils`
 - core: `crs` value in `LMap` now needs to be a value of `CRS` class
+- interactiveLayer: rename `bubblingMouseEvents` to `bubblingPointerEvents`, see [Leaflet v2](https://leafletjs.com/2025/05/18/leaflet-2.0.0-alpha.html#layers)
+  - also applies to ``Path``, ``Polyline``, ``Polygon``, ``CircleMarker``, ``Circle`` 
 - deprecate unreachable code (see [#56](https://github.com/Maxel01/vue-leaflet/pull/56))
 - types: remove `IMapBlueprint`
 

--- a/src/functions/interactiveLayer.ts
+++ b/src/functions/interactiveLayer.ts
@@ -12,18 +12,17 @@ export interface InteractiveLayerProps<T extends InteractiveLayerOptions = Inter
      * @initOnly
      */
     interactive?: boolean
-    // TODO in leaflet v2 it is bubblingPointerEvents
     /**
      * When `true`, a pointer event on this path will trigger the same event on the map (unless [DomEvent.stopPropagation](https://leafletjs.com/reference-2.0.0.html#domevent-stoppropagation) is used).
      * @initOnly
      */
-    bubblingMouseEvents?: boolean
+    bubblingPointerEvents?: boolean
 }
 
 export const interactiveLayerPropsDefaults = {
     ...layerPropsDefaults,
     interactive: undefined,
-    bubblingMouseEvents: undefined
+    bubblingPointerEvents: undefined
 }
 
 /* eslint-disable-next-line @typescript-eslint/no-empty-object-type */


### PR DESCRIPTION
Leaflet v2 introduces Pointer events instead of Mouse events. To follow the leaflet props, ``bubblingMouseEvents`` needs to be renamed to ``bubblingPointerEvents``
This is a breaking change.