### PR TITLE
feat(LTileLayer): add `tileLayerClass` from vue2-leaflet

### DIFF
--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
-import { TileLayer } from 'leaflet'
+import { type TileLayer } from 'leaflet'
 import { assertInject, propsBinder, remapEvents } from '@/utils'
 import { AddLayerInjection } from '@/types/injectionKeys'
 import {
@@ -35,7 +35,7 @@ function useTileLayer() {
     const { options, methods } = setupTileLayer(props, leafletObject, emit)
 
     onMounted(async () => {
-        leafletObject.value = markRaw<TileLayer>(new TileLayer(props.url, options))
+        leafletObject.value = markRaw<TileLayer>(props.tileLayerClass(props.url, options))
 
         const { listeners } = remapEvents(useAttrs())
         leafletObject.value.on(listeners)

--- a/src/functions/tileLayer.ts
+++ b/src/functions/tileLayer.ts
@@ -5,7 +5,7 @@ import {
     setupGridLayer
 } from './gridLayer'
 import type { Ref } from 'vue'
-import { type TileLayer, type TileLayerOptions } from 'leaflet'
+import { TileLayer, type TileLayerOptions } from 'leaflet'
 import { propsToLeafletOptions } from '@/utils'
 
 export interface TileLayerProps<
@@ -31,12 +31,20 @@ export interface TileLayerProps<
      * @reactive
      */
     url: string
+    /**
+     * A function that provides a TileLayer class. This prop may cause unintended errors, loss of reactivity or memory leaks if not used properly. Prefer creating a custom component if you encounter issues.
+     * @param url url of the TileLayer
+     * @param options options of the TileLayer
+     * @initOnly
+     */
+    tileLayerClass?: (url: string, options: TileLayerOptions) => TileLayer
 }
 
 export const tileLayerPropsDefaults = {
     ...gridLayerAbstractPropsDefaults,
     tms: undefined,
-    detectRetina: undefined
+    detectRetina: undefined,
+    tileLayerClass: (url: string, options: TileLayerOptions) => new TileLayer(url, options)
 }
 
 /* eslint-disable-next-line @typescript-eslint/no-empty-object-type */


### PR DESCRIPTION
This PR implements the `tileLayerClass` prop from vue2-leaflet. This feature could be a temporarily solution and might be moved to [`vue-leaflet-plugins`](https://github.com/Maxel01/vue-leaflet-plugins) as it is primarily needed for plugins. This would keep the main wrapper as clean as possible. See #152 for the discussion.

Resolves #152