### PR TITLE
docs: improve typing for array and union types

### DIFF
--- a/docs/scripts/handler.js
+++ b/docs/scripts/handler.js
@@ -6,12 +6,7 @@ const project = new Project({
 })
 project.addSourceFilesAtPaths('src/**/*')
 
-export default function propOriginHandler(
-    documentation,
-    _componentDefinition,
-    _astPath,
-    options
-) {
+export default function propOriginHandler(documentation, _componentDefinition, _astPath, options) {
     const filePath = options.filePath || ''
     const fileName = path.basename(filePath, '.vue')
 
@@ -20,8 +15,8 @@ export default function propOriginHandler(
 
     const interfaceDeclaration = project
         .getSourceFiles()
-        .flatMap(sf => sf.getInterfaces())
-        .find(i => i.getName() === interfaceName)
+        .flatMap((sf) => sf.getInterfaces())
+        .find((i) => i.getName() === interfaceName)
     if (!interfaceDeclaration) {
         console.warn(`[propOriginHandler] Interface "${interfaceName}" not found in ${filePath}`)
         return


### PR DESCRIPTION
The docs showed Array instead of the real type e.g. `string[]`. The typings have been improved to show the correct types.