### PR TITLE
fix(changelog): add missing url in heading.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.0-beta.5](///compare/v1.0.0-beta.4...v1.0.0-beta.5) (2025-12-14)
+## [1.0.0-beta.5](https://github.com/maxel01/vue-leaflet/compare/v1.0.0-beta.4...v1.0.0-beta.5) (2025-12-14)
 
 ### 📝 Documentation
 


### PR DESCRIPTION
With the incorrect conventional-changelog plugin version the changelog has been generated without the correct url in the heading.