### PR TITLE
feat(LMap): provide `mapObject` via injection

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -34,6 +34,7 @@ import type {
 } from '@/types/interfaces'
 import {
     AddLayerInjection,
+    GetMapObjectInjection,
     RegisterControlInjection,
     RegisterLayerControlInjection,
     RemoveLayerInjection
@@ -141,6 +142,10 @@ function useMethods() {
     const layerControl = ref<ILayerControlDefinition>()
     const layersToAdd = ref<ILayerDefinition[]>([])
 
+    function getMapObject(): Map | undefined {
+        return leafletObject.value
+    }
+
     function addLayer(layer: ILayerDefinition) {
         if (layer.layerType !== undefined) {
             if (layerControl.value === undefined) {
@@ -241,6 +246,7 @@ function useMethods() {
 
     return {
         methods: {
+            getMapObject,
             addLayer,
             removeLayer,
             registerLayerControl,
@@ -278,12 +284,14 @@ function useEvents() {
 }
 
 function useProvideFunctions() {
+    const mapObject = provideLeafletWrapper(GetMapObjectInjection)
     const addLayer = provideLeafletWrapper(AddLayerInjection)
     const removeLayer = provideLeafletWrapper(RemoveLayerInjection)
     const registerControl = provideLeafletWrapper(RegisterControlInjection)
     const registerLayerControl = provideLeafletWrapper(RegisterLayerControlInjection)
 
     onMounted(() => {
+        updateLeafletWrapper(mapObject, methods.getMapObject)
         updateLeafletWrapper(addLayer, methods.addLayer)
         updateLeafletWrapper(removeLayer, methods.removeLayer)
         updateLeafletWrapper(registerControl, methods.registerControl)

--- a/src/types/injectionKeys.ts
+++ b/src/types/injectionKeys.ts
@@ -1,7 +1,9 @@
 import type { InjectionKey } from 'vue'
 
 import type { IControlDefinition, ILayerDefinition } from './interfaces'
-import type { Control, DivIcon, Icon, Marker, Popup, Tooltip } from 'leaflet'
+import type { Control, DivIcon, Icon, Map, Marker, Popup, Tooltip } from 'leaflet'
+
+export const GetMapObjectInjection = Symbol('getMapObject') as InjectionKey<() => Map>
 
 export const AddLayerInjection = Symbol('addLayer') as InjectionKey<
     (layer: ILayerDefinition) => void

--- a/tests/helper/injectionsTests.ts
+++ b/tests/helper/injectionsTests.ts
@@ -1,5 +1,4 @@
-import type { VueWrapper } from '@vue/test-utils'
-import { flushPromises } from '@vue/test-utils'
+import { flushPromises, type VueWrapper } from '@vue/test-utils'
 import { beforeEach, expect, it, type Mock, vi } from 'vitest'
 
 export const mockRegisterControl = vi.fn()


### PR DESCRIPTION
In `vue2-leaflet` was a function called `findRealParent` which resolves the parent with a `mapObject`. Most use cases were replaced by dedicated injections such as `AddLayerInjection`. However, some use cases need access directly to the `mapObject`. The mapObject injection has been added.

### Open Tasks
- [ ] add tests for injection

Closes #160 