### PR TITLE
fix(LMap): remove event duplication

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -45,7 +45,7 @@ import { type MapEmits, type MapProps, mapPropsDefaults, setupMap } from '@/func
  * > Base component, contains and wraps all the other components.
  * @demo index {5,9-15}
  */
-defineOptions({ name: 'LMap' })
+defineOptions({ name: 'LMap', inheritAttrs: false })
 const props = withDefaults(defineProps<MapProps>(), mapPropsDefaults)
 
 const { root, leafletObject, ready } = useMap()


### PR DESCRIPTION
With Vue3 the events with will be passed to the child element automatically. This causes the event handler to be called twice with different arguments.
Setting `inheritAttrs` to `false` guarantees that only leaflet events will be emitted.

Closes #170