### PR TITLE
chore(ci): remove redundant upload artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,6 @@ jobs:
         run: pnpm run playwright:install
       - name: Run Playwright tests
         run: pnpm run test:e2e
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 7
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Upload Artifact does not have a valid directory and will be removed as playwright does only report the test results in the console. A html report is not necessary.