### PR TITLE
build: Change Dependabot update interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "14:00"
     open-pull-requests-limit: 5
@@ -24,5 +24,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 


### PR DESCRIPTION
Changed the update schedule for npm and GitHub Actions from weekly to monthly.